### PR TITLE
feat(skills): add skill support

### DIFF
--- a/docs/plans/2026-08-01-001-feat-skill-support-plan.md
+++ b/docs/plans/2026-08-01-001-feat-skill-support-plan.md
@@ -1,0 +1,462 @@
+---
+title: feat: Skill 支持（开放 Agent Skills 标准）
+type: feat
+status: active
+date: 2026-08-01
+updated: 2026-08-05
+origin: docs/brainstorms/2026-08-01-skill-support-requirements.md
+---
+
+> **2026-08-05 修订（Channel）：** Channel 语义改为「默认私有 + 显式频道投放」（原默认 all/全频道公开废止），取消「全平台公开」档（0=未投放），name 全局唯一不变，无存量数据不需迁移。本计划 status 由 completed 转 active，待办仅限下列修订点；其余 U1-U7 已实现（见 git）。
+>
+> **2026-08-05 修订（存储形态）：** 资源文件从技能行内 JSONB map 拆分为独立表 `agent_skill_file`（方案 B）：SKILL.md 留在 `agent_skill`，资源文件按「一行一文件」落库；内容统一 `bytea` 存储 + `mime`/`kind`（text/binary）元数据，文本按 UTF-8 字节存，二进制可存但不内联进 LLM 上下文。无存量数据，直接调整无需迁移；已实现的 U1/U2/U6/U7 需按新形态回改。
+
+# feat: Skill 支持
+
+## Summary
+
+以开放 Agent Skills 标准为格式，新增 DB 存储的 Skill bundle 与完整加载链路：前端圈定清单后 system prompt 只注入元数据，全文经 skill_read 按需加载（模型 MCP 调用 / 指令等效执行），清单小于阈值时直注全文；skill_read 返回 SKILL.md，skill_file_list 返回资源清单，资源内容经 skill_file_read 按需获取。CRUD 由 codegen 生成，用户自建接口手写，管理端与导入后置。2026-08-05 修订：Channel 默认私有 + 显式频道投放，取消全平台公开档；资源文件分表存储（`agent_skill_file`），SKILL.md 留在技能行。
+
+---
+
+## Problem Frame
+
+Morrigan 是 HTTP 后端，HTTP 聊天与 WeCom/飞书频道共用同一 system prompt 构建路径，但当前没有任何"程序化指令注入"能力，也没有可被模型与前端共同发现的技能单元。Skill 生态已收敛为开放 Agent Skills 标准（SKILL.md bundle + 渐进披露），旧方案（2026-04 skill-mcp-tools）未落地且形态已过时。完整背景见 origin 文档。
+
+---
+
+## Requirements
+
+本计划满足 origin 文档的全部需求（R1-R11），并补充实现级需求 R12-R13，trace 如下：
+
+- R1. Skill 以 bundle 形态存 DB，格式遵循开放 Agent Skills 标准（SKILL.md + scripts/references/assets）
+- R2. 实体共享字段：Channel 位掩码（默认私有/未投放）、owner、时间戳；name 全局唯一
+- R3. 上下文可见规则：Channel 显式投放的频道 ∪ 当前用户创建；未投放仅创建者可见
+- R4. REST 可见元数据列表与详情
+- R5. 用户可创建/编辑/删除自己的 skill；CRUD 由 codegen 生成，自建能力手写
+- R6. system prompt 默认只注入元数据（name+description）
+- R7. 清单数量小于阈值（默认 3，可配置）时直注全部 SKILL.md 全文
+- R8. 全文加载统一经 skill_read：模型 MCP 调用 / 指令等效执行；API skills 参数只圈定范围
+- R9. skill_read 返回 SKILL.md；skill_file_list 返回资源清单；skill_file_read 按需取内容
+- R10. 频道默认清单 = 可见集按时间前 N 条（N 可配置）；/skill 指令激活任意可见 skill
+- R11. 导入（URL / .skill / .zip）与全局管理接口后置，仅预留
+- R12. 不提供「全平台公开」档：公开只经显式投放（可多选 web/wecom/feishu），0 语义为未投放
+- R13. 资源文件分表存储：`agent_skill_file` 一行一文件（SKILL.md 仍在 `agent_skill.content`）；内容统一 `bytea`，`kind` 区分 text/binary，二进制不内联进 LLM 上下文
+
+**Origin actors:** A1 Web/API 用户、A2 频道用户、A3 LLM、A4 Keeper/管理员（后置）
+**Origin flows:** F1 Web 圈定清单并发起对话、F2 频道默认加载与指令激活、F3 LLM 分析命中加载全文
+**Origin acceptance examples:** AE1（小清单直注全文）、AE2（≥阈值仅元数据 + skill_read）、AE3（/skill 指令剥离文本并注入）、AE4（own 可见、他人不可见）、AE5（skill_file_read 按需、未调用不进上下文）
+
+---
+
+## Scope Boundaries
+
+- 管理端 CRUD（全局管理、分享管理、审核）不进本计划
+- 导入导出（URL / .skill / .zip）不进本计划（origin R11 仅预留）
+- 脚本执行不进 v1：脚本仅作为内容存取，执行仍归外部 Shell MCP
+- MCP skill_list 与 REST 列表同源（同一可见性查询）：skill_list 默认取少量条目供模型发现（频道侧无 REST 通道，是模型唯一的清单外发现入口）；REST 提供前端分页列表（web 圈定用）
+- 后端不持久化前端 last choices（前端职责）
+- 私有命名空间、版本化、skill 市场后置
+- 无「全平台公开」档：公开 = 显式勾选全部频道（2026-08-05 修订）；用户级/团队级分享继续后置
+
+### Deferred to Follow-Up Work
+
+- 管理端 CRUD 与导入导出（URL / .skill / .zip）：后续独立计划（对应 origin R11 后置项）
+- skill 指令别名与帮助文案：随管理端一起补充
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- codegen 管线：docs/mcps.yaml → pkg/models/mcps/mcps_gen.go、pkg/services/stores/mcps_gen.go、pkg/web/api/handle_mcps_gen.go；命令为 `make codegen MDs=docs/skills.yaml`；_gen.go 不手改，扩展走 _x.go
+- 工具注册：pkg/services/tools/registry.go（RegisterInvoker、initTools、privTools、频道工具集）、tools/defines.go（ToolDescriptor）、tools/invokers.go（参数解析与 BuildToolErrorResult 约定）
+- 指令机制：pkg/web/api/commands.go（commandRegistry、DetectCommand、Action 返回 handled 即停）；handle_platform.go:157 附近的消息处理分支
+- system prompt 构建：pkg/web/api/handle_convo.go prepareSystemMessage（HTTP 与频道共用，经 buildChatMessagesAndTools）；agent/prompt.go DefaultSystemMsg/DefaultToolsMsg
+- 请求参数：pkg/web/api/convo_basic.go ChatRequest（MCPs 字段已声明但全仓库无消费点——skills 为净新增）
+- 频道上下文：pkg/models/mcps/mcps_x.go ContextWithChannel/ChannelFromContext
+- 配置：pkg/settings/config.go envconfig 模式（KeeperRole、VectorThreshold 等）
+- Storage 接口：pkg/services/stores/interfaces.go 为手写，可扩展访问器；store 手写扩展参照 mcps_x.go
+- 权限：stores/auth.go IsKeeper + UserFromContext
+
+### Institutional Learnings
+
+- docs/solutions/runtime-errors/streaming-reply-multiple-startstream.md：流式回复循环中不得重复触发 StartStream。对本计划的约束：注入逻辑全部发生在消息构建期（prepareSystemMessage 与指令解析期），严禁进入流式循环
+- 频道级作用域先例：docs/plans/2026-06-02-001-feat-channel-mcp-tools-plan.md 证明"按频道上下文过滤工具"的可行性，skill 可见性过滤沿用同一上下文通道
+
+### External References
+
+- Agent Skills 开放标准（agentskills/agentskills specification）：SKILL.md YAML frontmatter（name/description 必填）、渐进披露三级加载、scripts/references/assets 目录约定、SKILL.md 建议 <500 行
+
+---
+
+## Key Technical Decisions
+
+- **单注入点**：prepareSystemMessage 同时服务 HTTP 与频道两条路径（已核实 buildChatMessagesAndTools 调用同一函数），skill 注入只挂这一处，避免双路径分叉
+- **skills 参数净新增**：ChatRequest.MCPs 声明但未消费，skills 参数消费逻辑无现成模式可复用，按"仅圈定清单范围"语义新写
+- **指令语义扩展**：现有 Command.Action 语义为"处理完即停"；skill 指令需要"注入全文后继续对话"，扩展 Command 结构（增加继续模式）而非为 skill 指令开特例分支
+- **共享加载器**：skill_read 工具、/skill 指令、详情 API 全部经同一可见性校验加载器（store 层 LoadForName）；分表后 LoadForName 只返回技能行（含 SKILL.md，不含资源文件），文件访问器（ListFileNames / ReadFile）仍先过同一可见性校验
+- **文件分表存储**：资源文件独立表 agent_skill_file（skill_id + path 复合唯一、content bytea、mime、kind、size）；bundle 为原子单元，创建/更新在事务内按 (skill_id, path) upsert（ON CONFLICT DO UPDATE），被移除的路径 DELETE 清理，不做文件级 diff
+- **文本/二进制存储**：content 统一 bytea，文本按 UTF-8 字节落库；kind 在写入时按 mime → 扩展名 → UTF-8/NUL 嗅探判定；skill_file_read 对 text 内联内容，对 binary 返回 path/mime/size 元数据并说明不可内联
+- **文件大小上限**：单文件默认 1MB、单技能总量默认 10MB（可配置），写入时校验
+- **阈值判定口径**：按"最终注入清单"（前端指定 + 默认补全合并后）的数量判定，而非可见技能总量
+- **Channel 位掩码**：复用 codegen 的 multiple 枚举先例（参照 mcps.yaml HeaderCate）；默认私有（未投放），0 语义为「未投放」而非「不限」，取消 all/全平台公开档，公开 = 显式勾选全部频道（2026-08-05 修订）
+- **可见性由 VisibleOnly 显式控制**：投放频道 + owner 规则在 store 层实施；ListVisibleMetadata 强制 VisibleOnly=true（防客户端绕过），管理端 ListSkill 不设标志、全量可见；工具/API/指令复用同一查询
+- **生成 CRUD 与自建接口分工**：codegen 生成的 CRUD（needPerm）面向 keeper；用户自建接口手写一层 owner 语义，两者并存
+- **skill_* 工具族全局注册、调用时校验**：与频道工具模式一致，避免按上下文动态组装工具集
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- 阈值判定口径：最终注入清单数量（用户已确认）
+- 指令机制扩展方向："处理并继续"语义（用户已确认方向）
+- skills 参数消费：净新增（MCPs 参数未接线，已核实）
+- Channel 语义与默认值（2026-08-05 修订：默认私有、取消 all/全平台公开档、0=未投放；用户已确认）
+
+### Deferred to Implementation
+
+- docs/skills.yaml 字段细节：agent_skill_file 模型字段命名（skills 包内模型直接命名 File，与 Skill 同文件定义、同文件生成，无独立 _gen 文件；存储结构已定：分表 + bytea/mime/kind，剩余为字段级细节）
+- 文件大小上限的配置项命名与默认值（方向：单文件 1MB、单技能总量 10MB）
+- skill_* 工具返回结构的精确 JSON 形状与内容截断上限
+- 阈值与 N 配置项的最终命名
+- /skill 指令的别名与匹配细节
+- 用户自建接口的 frontmatter 校验规则细节（YAML 解析库选择）
+
+---
+
+## Output Structure
+
+计划新增/生成的主要文件（生成产物由 codegen 产出，路径为预期形状）：
+
+    docs/skills.yaml                        # 模型定义（新建）
+    pkg/models/skills/skills_gen.go         # 生成：Skill 与 File 模型（同一 yaml 产出）
+    pkg/models/skills/skills_x.go           # 手写：frontmatter 校验、位掩码辅助
+    pkg/services/stores/skills_gen.go       # 生成：skillStore LGCUD
+    pkg/services/stores/skills_x.go         # 手写：可见性、加载器、默认清单、文件访问器与事务写入
+    pkg/web/api/handle_skills_gen.go        # 生成：keeper CRUD 路由
+    pkg/web/api/handle_skills_x.go          # 手写：路由挂载与手写接口
+    pkg/services/agent/skill_inject.go      # 手写：注入核心（新建）
+    pkg/services/tools/skills.go            # 手写：skill_* 工具（新建）
+    pkg/services/tools/skills_test.go       # 测试
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+加载决策流程：
+
+```mermaid
+flowchart TB
+    A[聊天请求进入] --> B{清单如何构成?}
+    B -->|HTTP: 前端 skills 参数| C[指定清单]
+    B -->|频道: 无参数| D[可见集按时间取前 N 条]
+    C --> E[合并去重得到最终注入清单]
+    D --> E
+    E --> F{清单数量 < 阈值?}
+    F -->|是| G[直注全部 SKILL.md 全文]
+    F -->|否| H[仅注入 name+description 元数据]
+    H --> I{命中方式}
+    I -->|模型调用| J[MCP skill_read]
+    I -->|指令 /skill name| K[后端等效执行 skill_read]
+    J --> L[按需 skill_file_read 取资源]
+    K --> L
+```
+
+组件接线：store 层提供唯一可见性加载器（LoadForName）；注入核心、skill_* 工具、/skill 指令、详情 API 全部消费同一加载器；注入核心只产出文本块，由 prepareSystemMessage 拼入 system prompt。
+
+---
+
+## Implementation Units
+
+### U1. docs/skills.yaml 与 codegen 骨架
+
+**Goal:** 新增 Skill 与 File 数据模型定义，跑通 codegen 生成模型/store/keeper CRUD 骨架，建立手写扩展文件。
+
+**Requirements:** R1, R2, R5, R13
+
+**Dependencies:** None
+
+**Files:**
+- Create: `docs/skills.yaml`（含 Skill 与 File 两个模型）
+- Generated: `pkg/models/skills/skills_gen.go`、`pkg/services/stores/skills_gen.go`、`pkg/web/api/handle_skills_gen.go`（由 `make codegen MDs=docs/skills.yaml` 产出，Skill 与 File 同文件生成）
+- Create: `pkg/models/skills/skills_x.go`、`pkg/services/stores/skills_x.go`、`pkg/web/api/handle_skills_x.go`
+- Test: `pkg/models/skills/skills_test.go`、`pkg/services/stores/skill_store_test.go`
+
+**Approach:**
+- 以 docs/mcps.yaml 为模板：enums 定义 Channel 位掩码（multiple:true，值 web/wecom/feishu；默认私有，0=未投放，取消 all 语义）；models 定义 Skill：Name（全局唯一 + match 查询）、Description、Content（SKILL.md 正文，不含资源文件）、Channel（位掩码枚举，默认未投放）、Owner（字符串 uid）、时间戳（comm.DefaultModel）
+- 新增 File 模型（agent_skill_file）：SkillID 与 Path 仅 basic（复合键，不可变更）、Content（bytea）、Mime、Kind（text/binary）、Size（字节）、时间戳；Content/Mime/Kind/Size 均 isset（可更新），Files JSONB 字段从 Skill 移除
+- stores 声明 skillStore（LGCUD），webapi 配 needAuth + needPerm、uris 前缀 /api/skill
+- 运行 codegen 生成骨架并提交产物；_gen.go 不手改，后续扩展全部落在 _x.go
+- 手写骨架先行落位：model 层 frontmatter 校验与位掩码辅助函数占位；store 层 afterLoad/afterList 钩子占位
+- 位掩码枚举值需按位对齐（1、2、4…）；0 表示未投放（仅 owner 可见），不再按通配处理（2026-08-05 修订，docs/skills.yaml 注释已同步为 0=无）
+
+**Patterns to follow:**
+- docs/mcps.yaml → mcps_gen.go / handle_mcps_gen.go 的生成对应关系
+- stores 生成 init 中 RegisterModel 注册模式
+
+**Test scenarios:**
+- Happy path: codegen 后模型字段与 JSON tag 与 spec 一致；skillStore CRUD 冒烟（create/get/update/delete）
+- Edge case: Channel 位掩码解码（单值 + 组合值）；默认值 = 未投放（0）；Name 唯一约束冲突返回明确错误
+- Error path: 非法枚举值拒绝写入
+- Integration: 创建带 owner 的记录后可按 id/name 读取（Covers AE4 的数据基础）
+
+**Verification:**
+- 模型与 store 相关测试目标通过；codegen 产物包含 Skill 与 File 模型、skillStore、/api/skill 路由注册
+
+---
+
+### U2. store 层：可见性、加载器与默认清单
+
+**Goal:** 在 skillStore 手写扩展中实现上下文可见规则、按名加载器（skill_read 工具与指令共用）、可见元数据列表与 top-N recent 查询，以及资源文件访问器与事务写入。
+
+**Requirements:** R3, R4, R8, R10, R13
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `pkg/services/stores/skills_x.go`、`pkg/services/stores/interfaces.go`
+- Test: `pkg/services/stores/skill_store_test.go`（集成）
+
+**Approach:**
+- 可见规则：可用 = Channel 显式投放到 ctx 频道（mcps.ChannelFromContext）或 Owner == ctx 用户（UserFromContext）；未投放（0）仅 Owner 可见
+- 查询接口：ListVisibleMetadata（仅 name+description）、GetVisible（含全文，校验可见）、TopRecent(n)（按创建时间倒序）
+- LoadForName(ctx, name)：统一可见性校验的加载器——skill_read 工具、指令注入、详情 API 全部经它；name 全局唯一，先按名加载（dbGetWith）、再在 Go 层校验可见性；越权返回 not found（不泄露存在性）；分表后仅返回技能行（content=SKILL.md），不再加载资源文件
+- 文件访问器：ListFileNames(ctx, name) 先经 LoadForName 过可见性，再只查 path+size+mime（不含 content）；ReadFile(ctx, name, path) 过可见性后按 (skill_id, path) 取单文件，binary 只返回元数据
+- 文件事务写入：CreateSkill/UpdateSkill 带资源文件时在事务内按 (skill_id, path) upsert（ON CONFLICT DO UPDATE，复合唯一键由手写 SQL 处理，生成的 dbInsert 仅支持单列冲突），被移除的路径 DELETE 清理；DeleteSkill 级联删除文件行；写入时按 mime → 扩展名 → UTF-8/NUL 嗅探判定 kind，并校验单文件/单技能大小上限
+- name 唯一冲突：依赖 DB unique 约束 + 错误映射，供 U7 使用
+
+**Patterns to follow:**
+- pkg/services/stores/mcps_x.go 的 afterLoad 钩子风格
+- pkg/models/mcps/mcps_x.go 的 ChannelFromContext 用法
+
+**Test scenarios:**
+- Happy path: 用户 A 可见自己的 skill + Channel 含当前频道的 skill；元数据列表不含 content
+- Edge case: 默认未投放（0）仅 owner 可见；显式投放后该频道所有用户可见；TopRecent 返回按时间倒序的前 N 条；binary 文件落库后 kind=binary、读取不内联内容；文件清单不含 content
+- Error path: 越权 LoadForName 返回 not found（Covers AE4）；name 冲突创建返回明确错误
+- Integration: 用户 B 在 wecom 看不到 A 未投放的 skill，而 A 自己在 wecom 可见自己的 skill（Covers AE4）
+
+**Verification:**
+- stores 集成测试通过；越权读取在 store 层被拒，工具/API/指令路径无需重复实现；文件访问器与事务整包写入有集成覆盖
+
+---
+
+### U3. 注入核心
+
+**Goal:** 实现注入决策与组装逻辑：给定上下文与清单（前端指定 + 默认补全），按阈值决定元数据或直注全文；提供指令注入入口（等效 skill_read）。
+
+**Requirements:** R6, R7, R8, R10
+
+**Dependencies:** U2
+
+**Files:**
+- Create: `pkg/services/agent/skill_inject.go`
+- Modify: `pkg/settings/config.go`（阈值与 N 配置项）
+- Test: `pkg/services/agent/skill_inject_test.go`
+
+**Approach:**
+- resolveList(ctx, requested)：HTTP 用前端指定清单，频道用 TopRecent(N) 默认清单，合并去重
+- 阈值判定（默认 3，可配置）：清单数量 < 阈值 → 逐条 LoadForName 组装全文；否则组装元数据块（name+description）
+- InjectByCommand(ctx, name)：LoadForName 后返回全文注入块，供 U5 使用——与 skill_read 工具同源
+- 输出为纯文本块（不直接写 system prompt），便于单测；注入块生成失败时降级（不阻塞对话）
+- 配置项：阈值默认 3、N 默认值（如 5），envconfig 模式
+
+**Patterns to follow:**
+- pkg/services/agent/prompt.go 的文本组装风格
+- pkg/settings/config.go envconfig 声明模式
+
+**Test scenarios:**
+- Happy path: 清单 2 个 → 返回两篇全文（Covers AE1）；清单 5 个 → 仅元数据块（Covers AE2）
+- Edge case: 空清单 → 空输出；清单含不可见 name → 跳过并保持其余；重复名去重；阈值边界（2/3/4）
+- Error path: 加载失败 → 降级为仅元数据或空，不返回错误阻塞对话
+- Integration: InjectByCommand 返回指定 skill 全文，不依赖 prompt 元数据（Covers AE3 前半）
+
+**Verification:**
+- agent 包测试通过；阈值边界与降级行为有明确断言
+
+---
+
+### U4. HTTP 装配：ChatRequest.Skills 与 system prompt 接入
+
+**Goal:** ChatRequest 新增 skills 参数并接入 system prompt 构建；HTTP 聊天请求可按清单注入元数据或全文。
+
+**Requirements:** R6, R7, R8（skills 参数只圈范围）
+
+**Dependencies:** U3
+
+**Files:**
+- Modify: `pkg/web/api/convo_basic.go`、`pkg/web/api/handle_convo.go`
+- Test: `pkg/web/api/handle_convo_test.go`
+
+**Approach:**
+- ChatRequest 新增 `Skills []string`（json:"skills,omitempty"，与 MCPs 同级）
+- prepareSystemMessage 在现有工具/知识库块之后追加注入块：resolveList(requested=Skills) → 按阈值输出元数据或全文
+- skills 参数只影响清单范围；全文触发仍由阈值与命中逻辑决定（不因参数直接注入）
+- 保持 prepareSystemMessage 为唯一注入点（频道共用）；如需调整函数签名，两个调用点（HTTP 与频道消息构建）同步更新
+
+**Patterns to follow:**
+- pkg/web/api/convo_basic.go 请求参数结构
+- prepareSystemMessage 现有块拼接顺序
+
+**Test scenarios:**
+- Happy path: skills 含 2 个 → system prompt 含全文（Covers AE1）；含 5 个 → 仅元数据（Covers AE2）
+- Edge case: 空 skills → 无注入块；不存在的 skill 名 → 跳过；与频道默认清单合并去重
+- Error path: 非法参数值 → 忽略或按现有参数校验风格拒绝
+- Integration: SSE 与非流式两条路径都带注入块；现有聊天测试无回归
+
+**Verification:**
+- HTTP chat 单测断言 system message 内容；现有聊天接口行为不变（无 skills 参数时无注入块）
+
+---
+
+### U5. skill 指令扩展与频道接入
+
+**Goal:** 新增 /skill <name> 指令：识别、剥离指令文本、等效执行 skill_read 注入全文并继续对话；扩展指令机制支持"处理并继续"。
+
+**Requirements:** R8, R10
+
+**Dependencies:** U3
+
+**Files:**
+- Modify: `pkg/web/api/commands.go`、`pkg/web/api/handle_platform.go`
+- Test: `pkg/web/api/commands_test.go`、`pkg/web/api/handle_platform_test.go`
+
+**Approach:**
+- 扩展 Command 结构支持"处理并继续"模式（skill 指令走此模式）；保留 /reset 等"处理完即停"行为
+- /skill <name>：解析 skill 名 → 调注入核心 InjectByCommand → 将注入块与剥离指令后的用户消息一起送入 LLM
+- 指令文本（/skill xxx）不出现在 LLM 上下文（Covers AE3）
+- 无指令时频道默认清单由 U3 resolveList 的默认分支（TopRecent N）承担
+
+**Patterns to follow:**
+- pkg/web/api/commands.go commandRegistry + DetectCommand
+- handle_platform.go:157 附近现有指令分支流程
+
+**Test scenarios:**
+- Happy path: WeCom 消息 "/skill invoice" → 全文注入且消息体无指令文本，继续正常 LLM 调用（Covers AE3）
+- Edge case: 未知名 → 回复提示并继续（不注入）；大小写与前后空白；非指令消息不受影响
+- Error path: 注入加载失败 → 提示失败但对话继续
+- Integration: /reset 行为不变（仍即停），频道默认清单注入正常（Covers AE2 频道侧）
+
+**Verification:**
+- 频道消息测试断言注入块存在、指令文本剥离、/reset 回归通过
+
+---
+
+### U6. 内嵌 MCP 工具 skill_* 族
+
+**Goal:** 注册 skill_list / skill_read / skill_file_list / skill_file_read 内嵌工具：模型可发现技能、拉取 SKILL.md 指令与资源内容；可见性校验复用 store 加载器。
+
+**Requirements:** R8, R9, R13
+
+**Dependencies:** U2
+
+**Files:**
+- Create: `pkg/services/tools/skills.go`
+- Modify: `pkg/services/tools/registry.go`（initTools 注册）
+- Test: `pkg/services/tools/skills_test.go`
+
+**Approach:**
+- skill_read(name)：经 LoadForName 可见性校验，返回 SKILL.md 正文；skill_file_list(name) 经 ListFileNames 返回资源文件清单（path+size+mime，不含内容）
+- skill_file_read(name, file)：经 ReadFile 读取单文件；kind=text 返回内容，kind=binary 返回 path/mime/size 元数据并说明不可内联；不存在/越权返回明确错误
+- skill_list(limit?)：复用可见元数据查询，默认取少量（10 条，上限 50）供模型发现；与 REST 列表同源
+- 全局注册、调用时校验（与频道工具模式一致）；注册为公开工具，与 kb_search 同级
+- 返回结构遵循 BuildToolSuccessResult 约定；内容上限实现期定
+
+**Patterns to follow:**
+- pkg/services/tools/defines.go 描述符、invokers.go 参数解析与 mcps.BuildToolErrorResult
+- registry.go initTools 注册点与 privTools（keeper 受限工具）先例
+
+**Test scenarios:**
+- Happy path: skill_read 返回正文；skill_file_list 返回排序后的文件名清单；skill_file_read 返回指定资源内容（Covers AE5）
+- Edge case: 无资源 skill → 空清单；资源名大小写与路径遍历防护；binary 文件读取返回元数据而非内容
+- Error path: 不可见 skill → not found（Covers AE4）；skill_file_read 不存在/越权 → 明确错误
+- Integration: 工具出现在 ToolsFor 列表且 Invoke 可调（复用现有工具测试模式）
+
+**Verification:**
+- tools 包测试通过；模型工具列表包含 skill_list / skill_read / skill_file_list / skill_file_read
+
+---
+
+### U7. 用户自建 REST API
+
+**Goal:** 在生成 CRUD 之上手写用户自建接口：创建/更新/删除自己的 skill（owner 强制、frontmatter 校验、Channel 默认私有/未投放），并提供可见清单/详情接口。
+
+**Requirements:** R4, R5, R13
+
+**Dependencies:** U2
+
+**Files:**
+- Create/Modify: `pkg/web/api/handle_skills_x.go`（或独立 skill 用户接口文件）
+- Test: `pkg/web/api/skill_user_test.go`
+
+**Approach:**
+- 生成 CRUD（needPerm）面向 keeper；用户自建接口手写：创建强制 owner=当前用户（dbBeforeCreateSkill 钩子在 store 层强制）、Channel 默认私有（不投放）、校验 SKILL.md frontmatter（name/description 必填、name 符合标准约束）、name 全局唯一冲突返回明确错误
+- 列表/详情复用 U2 可见性查询；更新/删除仅限 owner
+- 创建/更新请求体继续以 Files map[string]string（或 multipart 上传）携带资源，store 层在事务内展开为 agent_skill_file 行；详情接口返回文件清单（path+size+mime），内容按需经 skill_file_read，不在详情响应中内联
+- 越权请求统一拒绝；生成 CRUD 为 keeper 提供基础读写，管理功能（审核、分享管理、导入导出）后置
+
+**Patterns to follow:**
+- pkg/web/api/handle_mcps_x.go 手写扩展风格
+- stores/auth.go IsKeeper 与 UserFromContext
+
+**Test scenarios:**
+- Happy path: 创建后立即可见并出现在自身清单；带资源 bundle 创建成功
+- Edge case: frontmatter 缺 name/description → 校验错误；非法 name 字符 → 拒绝；Channel 缺省 → 私有（仅自己可见）；显式投放 wecom → 该频道用户可见
+- Error path: 更新/删除他人 skill → 拒绝（Covers AE4）；name 冲突 → 明确错误
+- Integration: 创建后可通过 chat skills 参数立即圈定（与 U4 联通）
+
+**Verification:**
+- API 测试覆盖 owner 语义、frontmatter 校验与冲突处理；make vet lint 通过
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** prepareSystemMessage 是 HTTP 与频道两条聊天路径的共用注入点；工具注册表新增两个内嵌工具影响 ToolsFor 返回集；命令注册表扩展影响 MessageHandler 指令分支；Storage 接口新增文件访问器与事务写入影响所有实现方（含 runner）
+- **Error propagation:** 注入加载失败降级（不阻塞对话）；工具错误走 BuildToolErrorResult；store 越权统一按 not found
+- **State lifecycle risks:** agent_skill_file 新表无迁移风险（无存量数据）；创建/更新的文件行与技能行必须同事务，删除依赖级联；codegen 重生成不得覆盖手写 _x.go；注入逻辑严禁进入流式循环（吸取 StartStream 多次触发教训）
+- **API surface parity:** 生成 CRUD（keeper）与手写自建接口（owner）职责划分需保持一致，避免同一动作两条路径语义不同
+- **Integration coverage:** chat skills 参数 → 注入 → 模型 skill_read 调用 → skill_file_read 链路需端到端验证
+- **Unchanged invariants:** 无 skills 参数/无指令时 system prompt 内容与现有行为不变；/reset 指令行为不变；现有工具列表不变
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| 注入内容体积失控（全文进入 prompt） | 清单 ≥ 阈值仅注入元数据；直注仅发生在小清单场景；skill_read / skill_file_read 返回体设内容上限 |
+| 越权读取/跨用户可见性泄露 | 可见性校验统一在 store 加载器，工具/API/指令共用，越权按 not found |
+| codegen 产物与手写代码冲突 | _gen.go 不手改，全部扩展走 _x.go；生成后立即提交 |
+| 指令机制改动引入回归 | /reset 等现有指令行为纳入回归测试 |
+| 弱模型不主动调 skill_read，全文能力受限 | 已知边界（脑暴决策）：清单 < 阈值直注 + 指令路径仍可用 |
+| 生成 CRUD 与自建接口权限语义混淆 | U7 明确分工：keeper 走生成 CRUD，owner 语义只在手写接口 |
+| 投放后 skill 内容可进入该频道所有用户的 prompt | 2026-08-05 修订后的已知决策：投放 = 显式同意内容对该频道公开并进入默认清单；默认未投放消除了「创建即公开」的意外 |
+| Channel 0 语义翻转（不限→未投放） | 无存量数据（2026-08-05 确认），直接翻转无需迁移；codegen 默认值与可见性查询同步修改，集成测试覆盖 |
+| 文件行与技能行不一致（bundle 写入失败） | 文件 upsert/删除与技能更新同一事务提交；技能删除时文件行一并清理；集成测试覆盖 |
+| 二进制文件被误读进 LLM 上下文 | kind 判定（mime/扩展名/嗅探）+ skill_file_read 对 binary 只返回元数据 |
+
+**Dependencies:** codegen 管线可用（已核实 Makefile 与 mcps 先例）；新表无需 pgvector；无外部服务依赖（执行仍归外部 Shell MCP，不在本计划）。
+
+---
+
+## Documentation / Operational Notes
+
+- swagger 文档由 codegen 更新（webapi 定义）
+- 新增配置项（注入阈值、频道默认 N、单文件/单技能大小上限）需在部署说明中标注
+- Channel 语义变更（默认私有、取消全平台公开档）需同步 swagger 注释与前端创建/编辑界面的投放选择展示
+- CHANGELOG 记录本特性；后置项（管理端、导入导出）在 brainstorms 中已标注
+
+---
+
+## Sources & References
+
+- **Origin document:** docs/brainstorms/2026-08-01-skill-support-requirements.md
+- 相关代码：pkg/services/tools/registry.go、pkg/web/api/commands.go、pkg/web/api/handle_convo.go、pkg/models/mcps/mcps_x.go、docs/mcps.yaml
+- 相关计划：docs/plans/2026-06-02-001-feat-channel-mcp-tools-plan.md
+- 外部标准：Agent Skills 开放标准（agentskills/agentskills specification）

--- a/docs/skills.yaml
+++ b/docs/skills.yaml
@@ -1,0 +1,145 @@
+
+depends:
+  comm: 'github.com/cupogo/andvari/models/comm'
+  oid: 'github.com/cupogo/andvari/models/oid'
+
+enums:
+
+  - comment: 技能可用频道 位掩码（0=未投放，仅创建者可见）
+    name: Channel
+    type: int8
+    values:
+      - label: 无
+        suffix: None
+      - label: Web
+        suffix: Web
+      - label: 企业微信
+        suffix: Wecom
+      - label: 飞书
+        suffix: Feishu
+    multiple: true
+    stringer: true
+    decodable: true
+    textMarshaler: true
+    textUnmarshaler: true
+
+  - comment: 技能资源文件类型
+    name: FileKind
+    type: int8
+    start: 1
+    values:
+      - label: 文本
+        suffix: Text
+      - label: 二进制
+        suffix: Binary
+    stringer: true
+    decodable: true
+    textMarshaler: true
+    textUnmarshaler: true
+
+dbcode: bun
+modelpkg: skills
+
+models:
+
+  - name: Skill
+    comment: '技能'
+    tableTag: 'agent_skill,alias:sk'
+    fields:
+      - type: comm.DefaultModel
+      - comment: 技能名 全局唯一（小写字母数字连字符）
+        name: Name
+        type: string
+        tags: {bson: 'name', json: 'name', pg: ',notnull,unique,type:name', binding: 'required'}
+        isset: true
+        query: 'match'
+      - comment: 技能描述 做什么+何时用
+        name: Description
+        type: string
+        tags: {bson: 'description', json: 'description', pg: ',notnull,type:varchar(124)'}
+        isset: true
+      - comment: 正文
+        name: Content
+        type: string
+        tags: {bson: 'content', json: 'content,omitempty', pg: ',notnull,type:text'}
+        isset: true
+      - comment: 可用频道 位掩码（0=未投放，仅创建者可见）
+        name: Channel
+        type: Channel
+        tags: {bson: 'channel', json: 'channel', pg: ',notnull,type:smallint,default:0'}
+        isset: true
+        query: 'equal,decode'
+      - comment: 创建者 uid
+        name: Owner
+        type: oid.OID
+        tags: {json: 'owner', pg: 'owner,notnull,type:bigint'}
+        basic: true
+        query: equal
+      - type: comm.MetaField
+    oidcat: file
+    hooks:
+      beforeCreating: yes
+      beforeDeleting: yes
+    specExtras:
+      - comment: 仅查看可见的
+        name: VisibleOnly
+        type: bool
+        tags: {form: 'visible', json: 'visible'}
+
+  - name: File
+    comment: '技能资源文件'
+    tableTag: 'agent_skill_file,alias:sf'
+    fields:
+      - type: comm.DefaultModel
+      - comment: 所属技能 id
+        name: SkillID
+        type: oid.OID
+        tags: {bson: 'skillId', json: 'skillId', pg: 'skill_id,notnull,type:bigint,unique:uk_skill_path'}
+        basic: true
+        query: 'equal'
+      - comment: 资源文件相对路径 技能内唯一
+        name: Path
+        type: string
+        tags: {bson: 'path', json: 'path', pg: ',notnull,type:varchar(255),unique:uk_skill_path'}
+        basic: true
+        query: 'equal'
+      - comment: 文件内容 文本按 UTF-8 字节存
+        name: Content
+        type: '[]byte'
+        tags: {bson: 'content', json: 'content,omitempty', pg: ',notnull,type:bytea'}
+        isset: true
+      - comment: 内容类型
+        name: Mime
+        type: string
+        tags: {bson: 'mime', json: 'mime,omitempty', pg: ',notnull,type:varchar(128)'}
+        isset: true
+      - comment: 文件类型
+        name: Kind
+        type: FileKind
+        tags: {bson: 'kind', json: 'kind,omitempty', pg: ',notnull,type:smallint'}
+        isset: true
+      - comment: 字节数
+        name: Size
+        type: int64
+        tags: {bson: 'size', json: 'size', pg: ',notnull,type:bigint'}
+        isset: true
+    oidcat: file
+
+stores:
+  - name: skillStore
+    iname: SkillStore
+    embed: SkillStoreX
+    siname: Skill
+    hods:
+      - { name: Skill, type: LGCUD }
+      - { name: File, type: L }
+
+webcode: chi
+webapi:
+  formTag: form
+  pkg: api
+  needAuth: true
+  needPerm: true
+  uris:
+    - model: Skill
+      prefix: '/api/admin'

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -10,6 +10,477 @@
         "version": "1.0"
     },
     "paths": {
+        "/api/admin/skills": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "默认 文档生成"
+                ],
+                "summary": "查询 技能 列表 🔑",
+                "operationId": "admin-skills-get",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "登录票据凭证",
+                        "name": "token",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "aaa,bbb,ccc",
+                        "x-order": "0",
+                        "description": "主键编号`ids`（以逗号分隔的字串），仅供 Form 或 Query 使用, example:\"aaa,bbb,ccc\"",
+                        "name": "ids",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "2",
+                        "description": "创建者ID",
+                        "name": "creatorID",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "3",
+                        "description": "创建时间 形式： yyyy-mm-dd, 1_day, 2_weeks, 3_months",
+                        "name": "created",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "4",
+                        "description": "更新时间 形式： yyyy-mm-dd, 1_day, 2_weeks, 3_months",
+                        "name": "updated",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "x-order": "5",
+                        "description": "IsDelete 查询删除的记录",
+                        "name": "isDelete",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "A",
+                        "description": "技能名 全局唯一（小写字母数字连字符）",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "B",
+                        "description": "可用频道 位掩码（0=未投放，仅创建者可见） (支持混合解码)\n * `web`\n * `wecom` - 企业微信\n * `feishu` - 飞书",
+                        "name": "channel",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "C",
+                        "description": "创建者 uid",
+                        "name": "owner",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "x-order": "D",
+                        "description": "仅查看可见的",
+                        "name": "visible",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "example": 1,
+                        "x-order": "[",
+                        "description": "第几页",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "x-order": "]",
+                        "description": "跳过多少条记录，如果提供 page 此项跳过",
+                        "name": "skip",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "x-order": "_",
+                        "description": "分页大小，默认20",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "|",
+                        "description": "排序，允许最多两个字段排序 field1 [asc | desc] [,field2 [asc | desc] ...]",
+                        "name": "sort",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.Done"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "result": {
+                                            "allOf": [
+                                                {
+                                                    "$ref": "#/definitions/api.ResultData"
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "data": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "$ref": "#/definitions/skillsSkill"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "请求或参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "401": {
+                        "description": "未登录",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "404": {
+                        "description": "目标未找到",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "503": {
+                        "description": "服务端错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "consumes": [
+                    "application/json",
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "默认 文档生成"
+                ],
+                "summary": "录入 技能 🔑",
+                "operationId": "admin-skills-post",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "登录票据凭证",
+                        "name": "token",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "description": "Object",
+                        "name": "query",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/skillsSkillBasic"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.Done"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "result": {
+                                            "$ref": "#/definitions/api.ResultID"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "请求或参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "401": {
+                        "description": "未登录",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "403": {
+                        "description": "无权限",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "503": {
+                        "description": "服务端错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/admin/skills/{id}": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "默认 文档生成"
+                ],
+                "summary": "获取 技能 详情 🔑",
+                "operationId": "admin-skills-id-get",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "登录票据凭证",
+                        "name": "token",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "编号",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.Done"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "result": {
+                                            "$ref": "#/definitions/skillsSkill"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "请求或参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "401": {
+                        "description": "未登录",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "404": {
+                        "description": "目标未找到",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "503": {
+                        "description": "服务端错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "consumes": [
+                    "application/json",
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "默认 文档生成"
+                ],
+                "summary": "更新 技能 🔑",
+                "operationId": "admin-skills-id-put",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "登录票据凭证",
+                        "name": "token",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "编号",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Object",
+                        "name": "query",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/skillsSkillSet"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.Done"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "result": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "请求或参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "401": {
+                        "description": "未登录",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "403": {
+                        "description": "无权限",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "503": {
+                        "description": "服务端错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "默认 文档生成"
+                ],
+                "summary": "删除 技能 🔑",
+                "operationId": "admin-skills-id-delete",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "登录票据凭证",
+                        "name": "token",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "编号",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.Done"
+                        }
+                    },
+                    "400": {
+                        "description": "请求或参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "401": {
+                        "description": "未登录",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "403": {
+                        "description": "无权限",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "503": {
+                        "description": "服务端错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    }
+                }
+            }
+        },
         "/api/chat": {
             "post": {
                 "consumes": [
@@ -179,7 +650,7 @@
                 "tags": [
                     "默认 文档生成"
                 ],
-                "summary": "列出消息",
+                "summary": "查询 消息 列表",
                 "parameters": [
                     {
                         "type": "string",
@@ -340,7 +811,7 @@
                 "tags": [
                     "默认 文档生成"
                 ],
-                "summary": "获取消息",
+                "summary": "获取 消息 详情",
                 "parameters": [
                     {
                         "type": "string",
@@ -412,7 +883,7 @@
                 "tags": [
                     "默认 文档生成"
                 ],
-                "summary": "删除消息 🔑",
+                "summary": "删除 消息 🔑",
                 "operationId": "convo-messages-id-delete",
                 "parameters": [
                     {
@@ -475,7 +946,7 @@
                 "tags": [
                     "默认 文档生成"
                 ],
-                "summary": "列出会话",
+                "summary": "查询 会话 列表",
                 "parameters": [
                     {
                         "type": "string",
@@ -537,6 +1008,13 @@
                     {
                         "type": "string",
                         "x-order": "C",
+                        "description": "频道",
+                        "name": "channel",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "D",
                         "description": "所有者编号 (多值使用逗号分隔)",
                         "name": "owner",
                         "in": "query"
@@ -643,7 +1121,7 @@
                 "tags": [
                     "默认 文档生成"
                 ],
-                "summary": "获取会话",
+                "summary": "获取 会话 详情",
                 "parameters": [
                     {
                         "type": "string",
@@ -715,7 +1193,7 @@
                 "tags": [
                     "默认 文档生成"
                 ],
-                "summary": "删除会话 🔑",
+                "summary": "删除 会话 🔑",
                 "operationId": "convo-sessions-id-delete",
                 "parameters": [
                     {
@@ -778,7 +1256,7 @@
                 "tags": [
                     "默认 文档生成"
                 ],
-                "summary": "列出使用情况",
+                "summary": "查询 使用情况 列表",
                 "parameters": [
                     {
                         "type": "string",
@@ -932,7 +1410,7 @@
                 "tags": [
                     "默认 文档生成"
                 ],
-                "summary": "获取使用情况",
+                "summary": "获取 使用情况 详情",
                 "parameters": [
                     {
                         "type": "string",
@@ -1004,7 +1482,7 @@
                 "tags": [
                     "默认 文档生成"
                 ],
-                "summary": "删除使用情况 🔑",
+                "summary": "删除 使用情况 🔑",
                 "operationId": "convo-usagerecords-id-delete",
                 "parameters": [
                     {
@@ -1058,6 +1536,7 @@
         },
         "/api/convo/users": {
             "get": {
+                "description": "\u003csortable\u003eid,created,updated,email\u003c/sortable\u003e",
                 "consumes": [
                     "application/json"
                 ],
@@ -1067,7 +1546,7 @@
                 "tags": [
                     "默认 文档生成"
                 ],
-                "summary": "列出用户",
+                "summary": "查询 用户 列表",
                 "parameters": [
                     {
                         "type": "string",
@@ -1242,7 +1721,7 @@
                 "tags": [
                     "默认 文档生成"
                 ],
-                "summary": "获取用户",
+                "summary": "获取 用户 详情",
                 "parameters": [
                     {
                         "type": "string",
@@ -1314,7 +1793,7 @@
                 "tags": [
                     "默认 文档生成"
                 ],
-                "summary": "删除用户 🔑",
+                "summary": "删除 用户 🔑",
                 "operationId": "convo-users-id-delete",
                 "parameters": [
                     {
@@ -1449,7 +1928,7 @@
                 "tags": [
                     "默认 文档生成"
                 ],
-                "summary": "列出服务器 🔑",
+                "summary": "查询 服务器 列表 🔑",
                 "operationId": "mcp-servers-get",
                 "parameters": [
                     {
@@ -1624,7 +2103,7 @@
                 "tags": [
                     "默认 文档生成"
                 ],
-                "summary": "录入服务器 🔑",
+                "summary": "录入 服务器 🔑",
                 "operationId": "mcp-servers-post",
                 "parameters": [
                     {
@@ -1701,7 +2180,7 @@
                 "tags": [
                     "默认 文档生成"
                 ],
-                "summary": "获取服务器 🔑",
+                "summary": "获取 服务器 详情 🔑",
                 "operationId": "mcp-servers-id-get",
                 "parameters": [
                     {
@@ -1775,7 +2254,7 @@
                 "tags": [
                     "默认 文档生成"
                 ],
-                "summary": "更新服务器 🔑",
+                "summary": "更新 服务器 🔑",
                 "operationId": "mcp-servers-id-put",
                 "parameters": [
                     {
@@ -1857,7 +2336,7 @@
                 "tags": [
                     "默认 文档生成"
                 ],
-                "summary": "删除服务器 🔑",
+                "summary": "删除 服务器 🔑",
                 "operationId": "mcp-servers-id-delete",
                 "parameters": [
                     {
@@ -2136,6 +2615,484 @@
                 }
             }
         },
+        "/api/skills": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "技能"
+                ],
+                "summary": "查询 可见技能列表（元数据）",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "登录票据凭证",
+                        "name": "token",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "aaa,bbb,ccc",
+                        "x-order": "0",
+                        "description": "主键编号`ids`（以逗号分隔的字串），仅供 Form 或 Query 使用, example:\"aaa,bbb,ccc\"",
+                        "name": "ids",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "2",
+                        "description": "创建者ID",
+                        "name": "creatorID",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "3",
+                        "description": "创建时间 形式： yyyy-mm-dd, 1_day, 2_weeks, 3_months",
+                        "name": "created",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "4",
+                        "description": "更新时间 形式： yyyy-mm-dd, 1_day, 2_weeks, 3_months",
+                        "name": "updated",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "x-order": "5",
+                        "description": "IsDelete 查询删除的记录",
+                        "name": "isDelete",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "A",
+                        "description": "技能名 全局唯一（小写字母数字连字符）",
+                        "name": "name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "B",
+                        "description": "可用频道 位掩码（0=未投放，仅创建者可见） (支持混合解码)\n * `web`\n * `wecom` - 企业微信\n * `feishu` - 飞书",
+                        "name": "channel",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "C",
+                        "description": "创建者 uid",
+                        "name": "owner",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "x-order": "D",
+                        "description": "仅查看可见的",
+                        "name": "visible",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "example": 1,
+                        "x-order": "[",
+                        "description": "第几页",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "x-order": "]",
+                        "description": "跳过多少条记录，如果提供 page 此项跳过",
+                        "name": "skip",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "x-order": "_",
+                        "description": "分页大小，默认20",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "|",
+                        "description": "排序，允许最多两个字段排序 field1 [asc | desc] [,field2 [asc | desc] ...]",
+                        "name": "sort",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.Done"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "result": {
+                                            "allOf": [
+                                                {
+                                                    "$ref": "#/definitions/api.ResultData"
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "data": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "$ref": "#/definitions/skillsSkill"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "请求或参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "401": {
+                        "description": "未登录",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "503": {
+                        "description": "服务端错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "consumes": [
+                    "application/json",
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "技能"
+                ],
+                "summary": "创建 自己的技能",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "登录票据凭证",
+                        "name": "token",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "description": "Object",
+                        "name": "query",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.skillCreateIn"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.Done"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "result": {
+                                            "$ref": "#/definitions/api.ResultID"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "请求或参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "401": {
+                        "description": "未登录",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "503": {
+                        "description": "服务端错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/skills/{name}": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "技能"
+                ],
+                "summary": "获取 技能详情",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "登录票据凭证",
+                        "name": "token",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "技能名",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.Done"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "result": {
+                                            "$ref": "#/definitions/api.skillDetail"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "请求或参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "401": {
+                        "description": "未登录",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "404": {
+                        "description": "目标未找到",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "503": {
+                        "description": "服务端错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "consumes": [
+                    "application/json",
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "技能"
+                ],
+                "summary": "更新 自己的技能",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "登录票据凭证",
+                        "name": "token",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "技能名",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Object",
+                        "name": "query",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.skillUpdateIn"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.Done"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "result": {
+                                            "$ref": "#/definitions/api.ResultID"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "请求或参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "401": {
+                        "description": "未登录",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "403": {
+                        "description": "无权限",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "404": {
+                        "description": "目标未找到",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "503": {
+                        "description": "服务端错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "技能"
+                ],
+                "summary": "删除 自己的技能",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "登录票据凭证",
+                        "name": "token",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "技能名",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.Done"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "result": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "请求或参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "401": {
+                        "description": "未登录",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "403": {
+                        "description": "无权限",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "404": {
+                        "description": "目标未找到",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "503": {
+                        "description": "服务端错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    }
+                }
+            }
+        },
         "/api/summary": {
             "post": {
                 "description": "根据聊天记录生成简短标题",
@@ -2316,6 +3273,10 @@
                 "a": {
                     "type": "string"
                 },
+                "th": {
+                    "description": "reasoning/thinking content",
+                    "type": "string"
+                },
                 "u": {
                     "type": "string"
                 }
@@ -2414,6 +3375,13 @@
                 },
                 "regen": {
                     "type": "boolean"
+                },
+                "skills": {
+                    "description": "技能清单范围：仅圈定注入 system prompt 的技能元数据",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "stream": {
                     "type": "boolean"
@@ -2574,6 +3542,159 @@
                 }
             }
         },
+        "api.skillCreateIn": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "description": "技能名 全局唯一（小写字母数字连字符）",
+                    "type": "string",
+                    "x-order": "A"
+                },
+                "description": {
+                    "description": "技能描述 做什么+何时用",
+                    "type": "string",
+                    "x-order": "B"
+                },
+                "content": {
+                    "description": "正文",
+                    "type": "string",
+                    "x-order": "C"
+                },
+                "channel": {
+                    "description": "可用频道 位掩码（0=未投放，仅创建者可见）\n * `web`\n * `wecom` - 企业微信\n * `feishu` - 飞书",
+                    "type": "string",
+                    "enum": [
+                        "web",
+                        "wecom",
+                        "feishu"
+                    ],
+                    "x-order": "D"
+                },
+                "owner": {
+                    "description": "创建者 uid",
+                    "type": "string",
+                    "x-order": "E"
+                },
+                "files": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "api.skillDetail": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "createdAt": {
+                    "description": "创建时间",
+                    "type": "string",
+                    "x-order": ""
+                },
+                "id": {
+                    "description": "主键",
+                    "type": "string",
+                    "x-order": "!"
+                },
+                "updatedAt": {
+                    "description": "变更时间",
+                    "type": "string",
+                    "x-order": "."
+                },
+                "name": {
+                    "description": "技能名 全局唯一（小写字母数字连字符）",
+                    "type": "string",
+                    "x-order": "A"
+                },
+                "description": {
+                    "description": "技能描述 做什么+何时用",
+                    "type": "string",
+                    "x-order": "B"
+                },
+                "content": {
+                    "description": "正文",
+                    "type": "string",
+                    "x-order": "C"
+                },
+                "channel": {
+                    "description": "可用频道 位掩码（0=未投放，仅创建者可见）\n * `web`\n * `wecom` - 企业微信\n * `feishu` - 飞书",
+                    "type": "string",
+                    "enum": [
+                        "web",
+                        "wecom",
+                        "feishu"
+                    ],
+                    "x-order": "D"
+                },
+                "owner": {
+                    "description": "创建者 uid",
+                    "type": "string",
+                    "x-order": "E"
+                },
+                "creatorID": {
+                    "description": "创建者ID",
+                    "type": "string",
+                    "x-order": "_"
+                },
+                "meta": {
+                    "description": "Meta 元信息",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Meta"
+                        }
+                    ],
+                    "x-order": "|"
+                },
+                "files": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/skillsFile"
+                    }
+                }
+            }
+        },
+        "api.skillUpdateIn": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "技能名 全局唯一（小写字母数字连字符）",
+                    "type": "string",
+                    "x-order": "A"
+                },
+                "description": {
+                    "description": "技能描述 做什么+何时用",
+                    "type": "string",
+                    "x-order": "B"
+                },
+                "content": {
+                    "description": "正文",
+                    "type": "string",
+                    "x-order": "C"
+                },
+                "channel": {
+                    "description": "可用频道 位掩码（0=未投放，仅创建者可见）\n * `web`\n * `wecom` - 企业微信\n * `feishu` - 飞书",
+                    "type": "string",
+                    "enum": [
+                        "web",
+                        "wecom",
+                        "feishu"
+                    ],
+                    "x-order": "D"
+                },
+                "files": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "api.verifyReq": {
             "type": "object",
             "properties": {
@@ -2690,6 +3811,11 @@
                         "type": "string"
                     },
                     "x-order": "D"
+                },
+                "channel": {
+                    "description": "频道",
+                    "type": "string",
+                    "x-order": "E"
                 },
                 "creatorID": {
                     "description": "创建者ID",
@@ -2925,6 +4051,11 @@
                     ],
                     "x-order": "H"
                 },
+                "channel": {
+                    "description": "频道名，非空时该 server 为频道专属",
+                    "type": "string",
+                    "x-order": "J"
+                },
                 "creatorID": {
                     "description": "创建者ID",
                     "type": "string",
@@ -3002,6 +4133,11 @@
                         "sessionID"
                     ],
                     "x-order": "H"
+                },
+                "channel": {
+                    "description": "频道名，非空时该 server 为频道专属",
+                    "type": "string",
+                    "x-order": "J"
                 }
             }
         },
@@ -3083,6 +4219,203 @@
                 "t": {
                     "description": "时间戳",
                     "type": "integer"
+                }
+            }
+        },
+        "skillsFile": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "description": "创建时间",
+                    "type": "string",
+                    "x-order": ""
+                },
+                "id": {
+                    "description": "主键",
+                    "type": "string",
+                    "x-order": "!"
+                },
+                "updatedAt": {
+                    "description": "变更时间",
+                    "type": "string",
+                    "x-order": "."
+                },
+                "skillId": {
+                    "description": "所属技能 id",
+                    "type": "string",
+                    "x-order": "A"
+                },
+                "path": {
+                    "description": "资源文件相对路径 技能内唯一",
+                    "type": "string",
+                    "x-order": "B"
+                },
+                "content": {
+                    "description": "文件内容 文本按 UTF-8 字节存",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    },
+                    "x-order": "C"
+                },
+                "mime": {
+                    "description": "内容类型",
+                    "type": "string",
+                    "x-order": "D"
+                },
+                "kind": {
+                    "description": "文件类型\n * `binary` - 二进制\n * `text` - 文本",
+                    "type": "string",
+                    "enum": [
+                        "binary",
+                        "text"
+                    ],
+                    "x-order": "E"
+                },
+                "size": {
+                    "description": "字节数",
+                    "type": "integer",
+                    "x-order": "F"
+                },
+                "creatorID": {
+                    "description": "创建者ID",
+                    "type": "string",
+                    "x-order": "_"
+                }
+            }
+        },
+        "skillsSkill": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "createdAt": {
+                    "description": "创建时间",
+                    "type": "string",
+                    "x-order": ""
+                },
+                "id": {
+                    "description": "主键",
+                    "type": "string",
+                    "x-order": "!"
+                },
+                "updatedAt": {
+                    "description": "变更时间",
+                    "type": "string",
+                    "x-order": "."
+                },
+                "name": {
+                    "description": "技能名 全局唯一（小写字母数字连字符）",
+                    "type": "string",
+                    "x-order": "A"
+                },
+                "description": {
+                    "description": "技能描述 做什么+何时用",
+                    "type": "string",
+                    "x-order": "B"
+                },
+                "content": {
+                    "description": "正文",
+                    "type": "string",
+                    "x-order": "C"
+                },
+                "channel": {
+                    "description": "可用频道 位掩码（0=未投放，仅创建者可见）\n * `web`\n * `wecom` - 企业微信\n * `feishu` - 飞书",
+                    "type": "string",
+                    "enum": [
+                        "web",
+                        "wecom",
+                        "feishu"
+                    ],
+                    "x-order": "D"
+                },
+                "owner": {
+                    "description": "创建者 uid",
+                    "type": "string",
+                    "x-order": "E"
+                },
+                "creatorID": {
+                    "description": "创建者ID",
+                    "type": "string",
+                    "x-order": "_"
+                },
+                "meta": {
+                    "description": "Meta 元信息",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Meta"
+                        }
+                    ],
+                    "x-order": "|"
+                }
+            }
+        },
+        "skillsSkillBasic": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "description": "技能名 全局唯一（小写字母数字连字符）",
+                    "type": "string",
+                    "x-order": "A"
+                },
+                "description": {
+                    "description": "技能描述 做什么+何时用",
+                    "type": "string",
+                    "x-order": "B"
+                },
+                "content": {
+                    "description": "正文",
+                    "type": "string",
+                    "x-order": "C"
+                },
+                "channel": {
+                    "description": "可用频道 位掩码（0=未投放，仅创建者可见）\n * `web`\n * `wecom` - 企业微信\n * `feishu` - 飞书",
+                    "type": "string",
+                    "enum": [
+                        "web",
+                        "wecom",
+                        "feishu"
+                    ],
+                    "x-order": "D"
+                },
+                "owner": {
+                    "description": "创建者 uid",
+                    "type": "string",
+                    "x-order": "E"
+                }
+            }
+        },
+        "skillsSkillSet": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "技能名 全局唯一（小写字母数字连字符）",
+                    "type": "string",
+                    "x-order": "A"
+                },
+                "description": {
+                    "description": "技能描述 做什么+何时用",
+                    "type": "string",
+                    "x-order": "B"
+                },
+                "content": {
+                    "description": "正文",
+                    "type": "string",
+                    "x-order": "C"
+                },
+                "channel": {
+                    "description": "可用频道 位掩码（0=未投放，仅创建者可见）\n * `web`\n * `wecom` - 企业微信\n * `feishu` - 飞书",
+                    "type": "string",
+                    "enum": [
+                        "web",
+                        "wecom",
+                        "feishu"
+                    ],
+                    "x-order": "D"
                 }
             }
         }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -7,6 +7,315 @@ info:
     url: https://github.com/liut
   version: "1.0"
 paths:
+  /api/admin/skills:
+    get:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - 默认 文档生成
+      summary: "查询 技能 列表 \U0001F511"
+      operationId: admin-skills-get
+      parameters:
+        - type: string
+          description: 登录票据凭证
+          name: token
+          in: header
+          required: true
+        - type: string
+          example: aaa,bbb,ccc
+          x-order: "0"
+          description: 主键编号`ids`（以逗号分隔的字串），仅供 Form 或 Query 使用, example:"aaa,bbb,ccc"
+          name: ids
+          in: query
+        - type: string
+          x-order: "2"
+          description: 创建者ID
+          name: creatorID
+          in: query
+        - type: string
+          x-order: "3"
+          description: 创建时间 形式： yyyy-mm-dd, 1_day, 2_weeks, 3_months
+          name: created
+          in: query
+        - type: string
+          x-order: "4"
+          description: 更新时间 形式： yyyy-mm-dd, 1_day, 2_weeks, 3_months
+          name: updated
+          in: query
+        - type: boolean
+          x-order: "5"
+          description: IsDelete 查询删除的记录
+          name: isDelete
+          in: query
+        - type: string
+          x-order: A
+          description: 技能名 全局唯一（小写字母数字连字符）
+          name: name
+          in: query
+        - type: string
+          x-order: B
+          description: |-
+            可用频道 位掩码（0=未投放，仅创建者可见） (支持混合解码)
+             * `web`
+             * `wecom` - 企业微信
+             * `feishu` - 飞书
+          name: channel
+          in: query
+        - type: string
+          x-order: C
+          description: 创建者 uid
+          name: owner
+          in: query
+        - type: boolean
+          x-order: D
+          description: 仅查看可见的
+          name: visible
+          in: query
+        - type: integer
+          example: 1
+          x-order: '['
+          description: 第几页
+          name: page
+          in: query
+        - type: integer
+          x-order: ']'
+          description: 跳过多少条记录，如果提供 page 此项跳过
+          name: skip
+          in: query
+        - type: integer
+          x-order: _
+          description: 分页大小，默认20
+          name: limit
+          in: query
+        - type: string
+          x-order: '|'
+          description: 排序，允许最多两个字段排序 field1 [asc | desc] [,field2 [asc | desc] ...]
+          name: sort
+          in: query
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+              - $ref: '#/definitions/api.Done'
+              - type: object
+                properties:
+                  result:
+                    allOf:
+                      - $ref: '#/definitions/api.ResultData'
+                      - type: object
+                        properties:
+                          data:
+                            type: array
+                            items:
+                              $ref: '#/definitions/skillsSkill'
+        "400":
+          description: 请求或参数错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "401":
+          description: 未登录
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "404":
+          description: 目标未找到
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "503":
+          description: 服务端错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+    post:
+      consumes:
+        - application/json
+        - multipart/form-data
+      produces:
+        - application/json
+      tags:
+        - 默认 文档生成
+      summary: "录入 技能 \U0001F511"
+      operationId: admin-skills-post
+      parameters:
+        - type: string
+          description: 登录票据凭证
+          name: token
+          in: header
+          required: true
+        - description: Object
+          name: query
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/skillsSkillBasic'
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+              - $ref: '#/definitions/api.Done'
+              - type: object
+                properties:
+                  result:
+                    $ref: '#/definitions/api.ResultID'
+        "400":
+          description: 请求或参数错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "401":
+          description: 未登录
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "403":
+          description: 无权限
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "503":
+          description: 服务端错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+  /api/admin/skills/{id}:
+    get:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - 默认 文档生成
+      summary: "获取 技能 详情 \U0001F511"
+      operationId: admin-skills-id-get
+      parameters:
+        - type: string
+          description: 登录票据凭证
+          name: token
+          in: header
+          required: true
+        - type: string
+          description: 编号
+          name: id
+          in: path
+          required: true
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+              - $ref: '#/definitions/api.Done'
+              - type: object
+                properties:
+                  result:
+                    $ref: '#/definitions/skillsSkill'
+        "400":
+          description: 请求或参数错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "401":
+          description: 未登录
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "404":
+          description: 目标未找到
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "503":
+          description: 服务端错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+    put:
+      consumes:
+        - application/json
+        - multipart/form-data
+      produces:
+        - application/json
+      tags:
+        - 默认 文档生成
+      summary: "更新 技能 \U0001F511"
+      operationId: admin-skills-id-put
+      parameters:
+        - type: string
+          description: 登录票据凭证
+          name: token
+          in: header
+          required: true
+        - type: string
+          description: 编号
+          name: id
+          in: path
+          required: true
+        - description: Object
+          name: query
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/skillsSkillSet'
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+              - $ref: '#/definitions/api.Done'
+              - type: object
+                properties:
+                  result:
+                    type: string
+        "400":
+          description: 请求或参数错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "401":
+          description: 未登录
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "403":
+          description: 无权限
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "503":
+          description: 服务端错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+    delete:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - 默认 文档生成
+      summary: "删除 技能 \U0001F511"
+      operationId: admin-skills-id-delete
+      parameters:
+        - type: string
+          description: 登录票据凭证
+          name: token
+          in: header
+          required: true
+        - type: string
+          description: 编号
+          name: id
+          in: path
+          required: true
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.Done'
+        "400":
+          description: 请求或参数错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "401":
+          description: 未登录
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "403":
+          description: 无权限
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "503":
+          description: 服务端错误
+          schema:
+            $ref: '#/definitions/api.Failure'
   /api/chat:
     post:
       consumes:
@@ -109,7 +418,7 @@ paths:
         - application/json
       tags:
         - 默认 文档生成
-      summary: 列出消息
+      summary: 查询 消息 列表
       parameters:
         - type: string
           description: 登录票据凭证
@@ -214,7 +523,7 @@ paths:
         - application/json
       tags:
         - 默认 文档生成
-      summary: 获取消息
+      summary: 获取 消息 详情
       parameters:
         - type: string
           description: 登录票据凭证
@@ -259,7 +568,7 @@ paths:
         - application/json
       tags:
         - 默认 文档生成
-      summary: "删除消息 \U0001F511"
+      summary: "删除 消息 \U0001F511"
       operationId: convo-messages-id-delete
       parameters:
         - type: string
@@ -301,7 +610,7 @@ paths:
         - application/json
       tags:
         - 默认 文档生成
-      summary: 列出会话
+      summary: 查询 会话 列表
       parameters:
         - type: string
           description: 登录票据凭证
@@ -349,6 +658,11 @@ paths:
           in: query
         - type: string
           x-order: C
+          description: 频道
+          name: channel
+          in: query
+        - type: string
+          x-order: D
           description: 所有者编号 (多值使用逗号分隔)
           name: owner
           in: query
@@ -414,7 +728,7 @@ paths:
         - application/json
       tags:
         - 默认 文档生成
-      summary: 获取会话
+      summary: 获取 会话 详情
       parameters:
         - type: string
           description: 登录票据凭证
@@ -459,7 +773,7 @@ paths:
         - application/json
       tags:
         - 默认 文档生成
-      summary: "删除会话 \U0001F511"
+      summary: "删除 会话 \U0001F511"
       operationId: convo-sessions-id-delete
       parameters:
         - type: string
@@ -501,7 +815,7 @@ paths:
         - application/json
       tags:
         - 默认 文档生成
-      summary: 列出使用情况
+      summary: 查询 使用情况 列表
       parameters:
         - type: string
           description: 登录票据凭证
@@ -601,7 +915,7 @@ paths:
         - application/json
       tags:
         - 默认 文档生成
-      summary: 获取使用情况
+      summary: 获取 使用情况 详情
       parameters:
         - type: string
           description: 登录票据凭证
@@ -646,7 +960,7 @@ paths:
         - application/json
       tags:
         - 默认 文档生成
-      summary: "删除使用情况 \U0001F511"
+      summary: "删除 使用情况 \U0001F511"
       operationId: convo-usagerecords-id-delete
       parameters:
         - type: string
@@ -682,13 +996,14 @@ paths:
             $ref: '#/definitions/api.Failure'
   /api/convo/users:
     get:
+      description: <sortable>id,created,updated,email</sortable>
       consumes:
         - application/json
       produces:
         - application/json
       tags:
         - 默认 文档生成
-      summary: 列出用户
+      summary: 查询 用户 列表
       parameters:
         - type: string
           description: 登录票据凭证
@@ -803,7 +1118,7 @@ paths:
         - application/json
       tags:
         - 默认 文档生成
-      summary: 获取用户
+      summary: 获取 用户 详情
       parameters:
         - type: string
           description: 登录票据凭证
@@ -848,7 +1163,7 @@ paths:
         - application/json
       tags:
         - 默认 文档生成
-      summary: "删除用户 \U0001F511"
+      summary: "删除 用户 \U0001F511"
       operationId: convo-users-id-delete
       parameters:
         - type: string
@@ -934,7 +1249,7 @@ paths:
         - application/json
       tags:
         - 默认 文档生成
-      summary: "列出服务器 \U0001F511"
+      summary: "查询 服务器 列表 \U0001F511"
       operationId: mcp-servers-get
       parameters:
         - type: string
@@ -1059,7 +1374,7 @@ paths:
         - application/json
       tags:
         - 默认 文档生成
-      summary: "录入服务器 \U0001F511"
+      summary: "录入 服务器 \U0001F511"
       operationId: mcp-servers-post
       parameters:
         - type: string
@@ -1107,7 +1422,7 @@ paths:
         - application/json
       tags:
         - 默认 文档生成
-      summary: "获取服务器 \U0001F511"
+      summary: "获取 服务器 详情 \U0001F511"
       operationId: mcp-servers-id-get
       parameters:
         - type: string
@@ -1154,7 +1469,7 @@ paths:
         - application/json
       tags:
         - 默认 文档生成
-      summary: "更新服务器 \U0001F511"
+      summary: "更新 服务器 \U0001F511"
       operationId: mcp-servers-id-put
       parameters:
         - type: string
@@ -1206,7 +1521,7 @@ paths:
         - application/json
       tags:
         - 默认 文档生成
-      summary: "删除服务器 \U0001F511"
+      summary: "删除 服务器 \U0001F511"
       operationId: mcp-servers-id-delete
       parameters:
         - type: string
@@ -1379,6 +1694,315 @@ paths:
                 properties:
                   result:
                     $ref: '#/definitions/api.respSession'
+  /api/skills:
+    get:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - 技能
+      summary: 查询 可见技能列表（元数据）
+      parameters:
+        - type: string
+          description: 登录票据凭证
+          name: token
+          in: header
+          required: true
+        - type: string
+          example: aaa,bbb,ccc
+          x-order: "0"
+          description: 主键编号`ids`（以逗号分隔的字串），仅供 Form 或 Query 使用, example:"aaa,bbb,ccc"
+          name: ids
+          in: query
+        - type: string
+          x-order: "2"
+          description: 创建者ID
+          name: creatorID
+          in: query
+        - type: string
+          x-order: "3"
+          description: 创建时间 形式： yyyy-mm-dd, 1_day, 2_weeks, 3_months
+          name: created
+          in: query
+        - type: string
+          x-order: "4"
+          description: 更新时间 形式： yyyy-mm-dd, 1_day, 2_weeks, 3_months
+          name: updated
+          in: query
+        - type: boolean
+          x-order: "5"
+          description: IsDelete 查询删除的记录
+          name: isDelete
+          in: query
+        - type: string
+          x-order: A
+          description: 技能名 全局唯一（小写字母数字连字符）
+          name: name
+          in: query
+        - type: string
+          x-order: B
+          description: |-
+            可用频道 位掩码（0=未投放，仅创建者可见） (支持混合解码)
+             * `web`
+             * `wecom` - 企业微信
+             * `feishu` - 飞书
+          name: channel
+          in: query
+        - type: string
+          x-order: C
+          description: 创建者 uid
+          name: owner
+          in: query
+        - type: boolean
+          x-order: D
+          description: 仅查看可见的
+          name: visible
+          in: query
+        - type: integer
+          example: 1
+          x-order: '['
+          description: 第几页
+          name: page
+          in: query
+        - type: integer
+          x-order: ']'
+          description: 跳过多少条记录，如果提供 page 此项跳过
+          name: skip
+          in: query
+        - type: integer
+          x-order: _
+          description: 分页大小，默认20
+          name: limit
+          in: query
+        - type: string
+          x-order: '|'
+          description: 排序，允许最多两个字段排序 field1 [asc | desc] [,field2 [asc | desc] ...]
+          name: sort
+          in: query
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+              - $ref: '#/definitions/api.Done'
+              - type: object
+                properties:
+                  result:
+                    allOf:
+                      - $ref: '#/definitions/api.ResultData'
+                      - type: object
+                        properties:
+                          data:
+                            type: array
+                            items:
+                              $ref: '#/definitions/skillsSkill'
+        "400":
+          description: 请求或参数错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "401":
+          description: 未登录
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "503":
+          description: 服务端错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+    post:
+      consumes:
+        - application/json
+        - multipart/form-data
+      produces:
+        - application/json
+      tags:
+        - 技能
+      summary: 创建 自己的技能
+      parameters:
+        - type: string
+          description: 登录票据凭证
+          name: token
+          in: header
+          required: true
+        - description: Object
+          name: query
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/api.skillCreateIn'
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+              - $ref: '#/definitions/api.Done'
+              - type: object
+                properties:
+                  result:
+                    $ref: '#/definitions/api.ResultID'
+        "400":
+          description: 请求或参数错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "401":
+          description: 未登录
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "503":
+          description: 服务端错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+  /api/skills/{name}:
+    get:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - 技能
+      summary: 获取 技能详情
+      parameters:
+        - type: string
+          description: 登录票据凭证
+          name: token
+          in: header
+          required: true
+        - type: string
+          description: 技能名
+          name: name
+          in: path
+          required: true
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+              - $ref: '#/definitions/api.Done'
+              - type: object
+                properties:
+                  result:
+                    $ref: '#/definitions/api.skillDetail'
+        "400":
+          description: 请求或参数错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "401":
+          description: 未登录
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "404":
+          description: 目标未找到
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "503":
+          description: 服务端错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+    put:
+      consumes:
+        - application/json
+        - multipart/form-data
+      produces:
+        - application/json
+      tags:
+        - 技能
+      summary: 更新 自己的技能
+      parameters:
+        - type: string
+          description: 登录票据凭证
+          name: token
+          in: header
+          required: true
+        - type: string
+          description: 技能名
+          name: name
+          in: path
+          required: true
+        - description: Object
+          name: query
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/api.skillUpdateIn'
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+              - $ref: '#/definitions/api.Done'
+              - type: object
+                properties:
+                  result:
+                    $ref: '#/definitions/api.ResultID'
+        "400":
+          description: 请求或参数错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "401":
+          description: 未登录
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "403":
+          description: 无权限
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "404":
+          description: 目标未找到
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "503":
+          description: 服务端错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+    delete:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - 技能
+      summary: 删除 自己的技能
+      parameters:
+        - type: string
+          description: 登录票据凭证
+          name: token
+          in: header
+          required: true
+        - type: string
+          description: 技能名
+          name: name
+          in: path
+          required: true
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+              - $ref: '#/definitions/api.Done'
+              - type: object
+                properties:
+                  result:
+                    type: string
+        "400":
+          description: 请求或参数错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "401":
+          description: 未登录
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "403":
+          description: 无权限
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "404":
+          description: 目标未找到
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "503":
+          description: 服务端错误
+          schema:
+            $ref: '#/definitions/api.Failure'
   /api/summary:
     post:
       description: 根据聊天记录生成简短标题
@@ -1488,6 +2112,9 @@ definitions:
     properties:
       a:
         type: string
+      th:
+        description: reasoning/thinking content
+        type: string
       u:
         type: string
   aigc.HistoryItem:
@@ -1553,6 +2180,11 @@ definitions:
         type: string
       regen:
         type: boolean
+      skills:
+        description: 技能清单范围：仅圈定注入 system prompt 的技能元数据
+        type: array
+        items:
+          type: string
       stream:
         type: boolean
   api.Done:
@@ -1660,6 +2292,132 @@ definitions:
               - $ref: '#/definitions/api.User'
       status:
         type: string
+  api.skillCreateIn:
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        description: 技能名 全局唯一（小写字母数字连字符）
+        type: string
+        x-order: A
+      description:
+        description: 技能描述 做什么+何时用
+        type: string
+        x-order: B
+      content:
+        description: 正文
+        type: string
+        x-order: C
+      channel:
+        description: |-
+          可用频道 位掩码（0=未投放，仅创建者可见）
+           * `web`
+           * `wecom` - 企业微信
+           * `feishu` - 飞书
+        type: string
+        enum:
+          - web
+          - wecom
+          - feishu
+        x-order: D
+      owner:
+        description: 创建者 uid
+        type: string
+        x-order: E
+      files:
+        type: object
+        additionalProperties:
+          type: string
+  api.skillDetail:
+    type: object
+    required:
+      - name
+    properties:
+      createdAt:
+        description: 创建时间
+        type: string
+        x-order: ""
+      id:
+        description: 主键
+        type: string
+        x-order: '!'
+      updatedAt:
+        description: 变更时间
+        type: string
+        x-order: .
+      name:
+        description: 技能名 全局唯一（小写字母数字连字符）
+        type: string
+        x-order: A
+      description:
+        description: 技能描述 做什么+何时用
+        type: string
+        x-order: B
+      content:
+        description: 正文
+        type: string
+        x-order: C
+      channel:
+        description: |-
+          可用频道 位掩码（0=未投放，仅创建者可见）
+           * `web`
+           * `wecom` - 企业微信
+           * `feishu` - 飞书
+        type: string
+        enum:
+          - web
+          - wecom
+          - feishu
+        x-order: D
+      owner:
+        description: 创建者 uid
+        type: string
+        x-order: E
+      creatorID:
+        description: 创建者ID
+        type: string
+        x-order: _
+      meta:
+        description: Meta 元信息
+        allOf:
+          - $ref: '#/definitions/Meta'
+        x-order: '|'
+      files:
+        type: array
+        items:
+          $ref: '#/definitions/skillsFile'
+  api.skillUpdateIn:
+    type: object
+    properties:
+      name:
+        description: 技能名 全局唯一（小写字母数字连字符）
+        type: string
+        x-order: A
+      description:
+        description: 技能描述 做什么+何时用
+        type: string
+        x-order: B
+      content:
+        description: 正文
+        type: string
+        x-order: C
+      channel:
+        description: |-
+          可用频道 位掩码（0=未投放，仅创建者可见）
+           * `web`
+           * `wecom` - 企业微信
+           * `feishu` - 飞书
+        type: string
+        enum:
+          - web
+          - wecom
+          - feishu
+        x-order: D
+      files:
+        type: object
+        additionalProperties:
+          type: string
   api.verifyReq:
     type: object
     properties:
@@ -1752,6 +2510,10 @@ definitions:
         items:
           type: string
         x-order: D
+      channel:
+        description: 频道
+        type: string
+        x-order: E
       creatorID:
         description: 创建者ID
         type: string
@@ -1940,6 +2702,10 @@ definitions:
           - ownerID
           - sessionID
         x-order: H
+      channel:
+        description: 频道名，非空时该 server 为频道专属
+        type: string
+        x-order: J
       creatorID:
         description: 创建者ID
         type: string
@@ -2012,6 +2778,10 @@ definitions:
           - ownerID
           - sessionID
         x-order: H
+      channel:
+        description: 频道名，非空时该 server 为频道专属
+        type: string
+        x-order: J
   mcpsServerSet:
     type: object
     properties:
@@ -2087,3 +2857,168 @@ definitions:
       t:
         description: 时间戳
         type: integer
+  skillsFile:
+    type: object
+    properties:
+      createdAt:
+        description: 创建时间
+        type: string
+        x-order: ""
+      id:
+        description: 主键
+        type: string
+        x-order: '!'
+      updatedAt:
+        description: 变更时间
+        type: string
+        x-order: .
+      skillId:
+        description: 所属技能 id
+        type: string
+        x-order: A
+      path:
+        description: 资源文件相对路径 技能内唯一
+        type: string
+        x-order: B
+      content:
+        description: 文件内容 文本按 UTF-8 字节存
+        type: array
+        items:
+          type: integer
+        x-order: C
+      mime:
+        description: 内容类型
+        type: string
+        x-order: D
+      kind:
+        description: |-
+          文件类型
+           * `binary` - 二进制
+           * `text` - 文本
+        type: string
+        enum:
+          - binary
+          - text
+        x-order: E
+      size:
+        description: 字节数
+        type: integer
+        x-order: F
+      creatorID:
+        description: 创建者ID
+        type: string
+        x-order: _
+  skillsSkill:
+    type: object
+    required:
+      - name
+    properties:
+      createdAt:
+        description: 创建时间
+        type: string
+        x-order: ""
+      id:
+        description: 主键
+        type: string
+        x-order: '!'
+      updatedAt:
+        description: 变更时间
+        type: string
+        x-order: .
+      name:
+        description: 技能名 全局唯一（小写字母数字连字符）
+        type: string
+        x-order: A
+      description:
+        description: 技能描述 做什么+何时用
+        type: string
+        x-order: B
+      content:
+        description: 正文
+        type: string
+        x-order: C
+      channel:
+        description: |-
+          可用频道 位掩码（0=未投放，仅创建者可见）
+           * `web`
+           * `wecom` - 企业微信
+           * `feishu` - 飞书
+        type: string
+        enum:
+          - web
+          - wecom
+          - feishu
+        x-order: D
+      owner:
+        description: 创建者 uid
+        type: string
+        x-order: E
+      creatorID:
+        description: 创建者ID
+        type: string
+        x-order: _
+      meta:
+        description: Meta 元信息
+        allOf:
+          - $ref: '#/definitions/Meta'
+        x-order: '|'
+  skillsSkillBasic:
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        description: 技能名 全局唯一（小写字母数字连字符）
+        type: string
+        x-order: A
+      description:
+        description: 技能描述 做什么+何时用
+        type: string
+        x-order: B
+      content:
+        description: 正文
+        type: string
+        x-order: C
+      channel:
+        description: |-
+          可用频道 位掩码（0=未投放，仅创建者可见）
+           * `web`
+           * `wecom` - 企业微信
+           * `feishu` - 飞书
+        type: string
+        enum:
+          - web
+          - wecom
+          - feishu
+        x-order: D
+      owner:
+        description: 创建者 uid
+        type: string
+        x-order: E
+  skillsSkillSet:
+    type: object
+    properties:
+      name:
+        description: 技能名 全局唯一（小写字母数字连字符）
+        type: string
+        x-order: A
+      description:
+        description: 技能描述 做什么+何时用
+        type: string
+        x-order: B
+      content:
+        description: 正文
+        type: string
+        x-order: C
+      channel:
+        description: |-
+          可用频道 位掩码（0=未投放，仅创建者可见）
+           * `web`
+           * `wecom` - 企业微信
+           * `feishu` - 飞书
+        type: string
+        enum:
+          - web
+          - wecom
+          - feishu
+        x-order: D

--- a/pkg/models/channel/message.go
+++ b/pkg/models/channel/message.go
@@ -31,6 +31,7 @@ type Message struct {
 	UserName   string
 	ChatName   string // human-readable chat/group name (optional)
 	Content    string
+	SkillName  string // /skill 指令激活的技能名（注入全文后从 Content 剥离）
 	Images     []ImageAttachment // attached images (if any)
 	Files      []FileAttachment  // attached files (if any)
 	Audio      *AudioAttachment  // voice message (if any)

--- a/pkg/models/skills/skills_gen.go
+++ b/pkg/models/skills/skills_gen.go
@@ -1,0 +1,295 @@
+// This file is generated - Do Not Edit.
+
+package skills
+
+import (
+	"fmt"
+
+	comm "github.com/cupogo/andvari/models/comm"
+	oid "github.com/cupogo/andvari/models/oid"
+)
+
+// 技能可用频道 位掩码（0=未投放，仅创建者可见）
+type Channel int8
+
+const (
+	ChannelWeb    Channel = 1 << iota //   1 Web
+	ChannelWecom                      //   2 企业微信
+	ChannelFeishu                     //   4 飞书
+
+	ChannelNone Channel = 0 // 无
+)
+
+func (z *Channel) Decode(s string) error {
+	switch s {
+	case "0", "none":
+		*z = ChannelNone
+	case "1", "web", "Web":
+		*z = ChannelWeb
+	case "2", "wecom", "Wecom":
+		*z = ChannelWecom
+	case "4", "feishu", "Feishu":
+		*z = ChannelFeishu
+	default:
+		return fmt.Errorf("invalid channel: %q", s)
+	}
+	return nil
+}
+func (z *Channel) UnmarshalText(b []byte) error {
+	return z.Decode(string(b))
+}
+func (z Channel) String() string {
+	switch z {
+	case ChannelNone:
+		return "none"
+	case ChannelWeb:
+		return "web"
+	case ChannelWecom:
+		return "wecom"
+	case ChannelFeishu:
+		return "feishu"
+	default:
+		return fmt.Sprintf("channel %d", int8(z))
+	}
+}
+func (z Channel) MarshalText() ([]byte, error) {
+	return []byte(z.String()), nil
+}
+
+// 技能资源文件类型
+type FileKind int8
+
+const (
+	FileKindText   FileKind = 1 + iota //  1 文本
+	FileKindBinary                     //  2 二进制
+)
+
+func (z *FileKind) Decode(s string) error {
+	switch s {
+	case "1", "text", "Text":
+		*z = FileKindText
+	case "2", "binary", "Binary":
+		*z = FileKindBinary
+	default:
+		return fmt.Errorf("invalid fileKind: %q", s)
+	}
+	return nil
+}
+func (z *FileKind) UnmarshalText(b []byte) error {
+	return z.Decode(string(b))
+}
+func (z FileKind) String() string {
+	switch z {
+	case FileKindText:
+		return "text"
+	case FileKindBinary:
+		return "binary"
+	default:
+		return fmt.Sprintf("fileKind %d", int8(z))
+	}
+}
+func (z FileKind) MarshalText() ([]byte, error) {
+	return []byte(z.String()), nil
+}
+
+// consts of Skill 技能
+const (
+	SkillTable = "agent_skill"
+	SkillAlias = "sk"
+	SkillLabel = "skill"
+	SkillTypID = "skillsSkill"
+)
+
+// Skill 技能
+type Skill struct {
+	comm.BaseModel `bun:"table:agent_skill,alias:sk" json:"-"`
+
+	comm.DefaultModel
+
+	SkillBasic
+
+	comm.MetaField
+} // @name skillsSkill
+
+type SkillBasic struct {
+	// 技能名 全局唯一（小写字母数字连字符）
+	Name string `binding:"required" bson:"name" bun:",notnull,unique,type:name" extensions:"x-order=A" form:"name" json:"name" pg:",notnull,unique,type:name"`
+	// 技能描述 做什么+何时用
+	Description string `bson:"description" bun:",notnull,type:varchar(124)" extensions:"x-order=B" form:"description" json:"description" pg:",notnull,type:varchar(124)"`
+	// 正文
+	Content string `bson:"content" bun:",notnull,type:text" extensions:"x-order=C" form:"content" json:"content,omitempty" pg:",notnull,type:text"`
+	// 可用频道 位掩码（0=未投放，仅创建者可见）
+	//  * `web`
+	//  * `wecom` - 企业微信
+	//  * `feishu` - 飞书
+	Channel Channel `bson:"channel" bun:",notnull,type:smallint,default:0" enums:"web,wecom,feishu" extensions:"x-order=D" json:"channel" pg:",notnull,type:smallint,default:0" swaggertype:"string"`
+	// 创建者 uid
+	Owner oid.OID `bun:"owner,notnull,type:bigint" extensions:"x-order=E" json:"owner" pg:"owner,notnull,type:bigint" swaggertype:"string"`
+	// for meta update
+	MetaDiff *comm.MetaDiff `bson:"-" bun:"-" json:"metaUp,omitempty" pg:"-" swaggerignore:"true"`
+} // @name skillsSkillBasic
+
+type Skills []Skill
+
+// Creating function call to it's inner fields defined hooks
+func (z *Skill) Creating() error {
+	if z.IsZeroID() {
+		z.SetID(oid.NewID(oid.OtFile))
+	}
+
+	return z.DefaultModel.Creating()
+}
+func NewSkillWithBasic(in SkillBasic) *Skill {
+	obj := &Skill{
+		SkillBasic: in,
+	}
+	_ = obj.MetaUp(in.MetaDiff)
+	return obj
+}
+func NewSkillWithID(id any) *Skill {
+	obj := new(Skill)
+	_ = obj.SetID(id)
+	return obj
+}
+func (_ *Skill) IdentityLabel() string { return SkillLabel }
+func (_ *Skill) IdentityModel() string { return SkillTypID }
+func (_ *Skill) IdentityTable() string { return SkillTable }
+func (_ *Skill) IdentityAlias() string { return SkillAlias }
+
+type SkillSet struct {
+	// 技能名 全局唯一（小写字母数字连字符）
+	Name *string `extensions:"x-order=A" json:"name"`
+	// 技能描述 做什么+何时用
+	Description *string `extensions:"x-order=B" json:"description"`
+	// 正文
+	Content *string `extensions:"x-order=C" form:"content" json:"content,omitempty"`
+	// 可用频道 位掩码（0=未投放，仅创建者可见）
+	//  * `web`
+	//  * `wecom` - 企业微信
+	//  * `feishu` - 飞书
+	Channel *Channel `enums:"web,wecom,feishu" extensions:"x-order=D" json:"channel" swaggertype:"string"`
+	// for meta update
+	MetaDiff *comm.MetaDiff `json:"metaUp,omitempty" swaggerignore:"true"`
+} // @name skillsSkillSet
+
+func (z *Skill) SetWith(o SkillSet) {
+	if o.Name != nil && z.Name != *o.Name {
+		z.LogChangeValue("name", z.Name, o.Name)
+		z.Name = *o.Name
+	}
+	if o.Description != nil && z.Description != *o.Description {
+		z.LogChangeValue("description", z.Description, o.Description)
+		z.Description = *o.Description
+	}
+	if o.Content != nil && z.Content != *o.Content {
+		z.LogChangeValue("content", z.Content, o.Content)
+		z.Content = *o.Content
+	}
+	if o.Channel != nil {
+		z.LogChangeValue("channel", z.Channel, o.Channel)
+		z.Channel = *o.Channel
+	}
+	if o.MetaDiff != nil && z.MetaUp(o.MetaDiff) {
+		z.SetChange("meta")
+	}
+}
+func (in *SkillBasic) MetaAddKVs(args ...any) *SkillBasic {
+	in.MetaDiff = comm.MetaDiffAddKVs(in.MetaDiff, args...)
+	return in
+}
+func (in *SkillSet) MetaAddKVs(args ...any) *SkillSet {
+	in.MetaDiff = comm.MetaDiffAddKVs(in.MetaDiff, args...)
+	return in
+}
+
+// consts of File 技能资源文件
+const (
+	FileTable = "agent_skill_file"
+	FileAlias = "sf"
+	FileLabel = "file"
+	FileTypID = "skillsFile"
+)
+
+// File 技能资源文件
+type File struct {
+	comm.BaseModel `bun:"table:agent_skill_file,alias:sf" json:"-"`
+
+	comm.DefaultModel
+
+	FileBasic
+} // @name skillsFile
+
+type FileBasic struct {
+	// 所属技能 id
+	SkillID oid.OID `bson:"skillId" bun:"skill_id,notnull,type:bigint,unique:uk_skill_path" extensions:"x-order=A" json:"skillId" pg:"skill_id,notnull,type:bigint,unique:uk_skill_path" swaggertype:"string"`
+	// 资源文件相对路径 技能内唯一
+	Path string `bson:"path" bun:",notnull,type:varchar(255),unique:uk_skill_path" extensions:"x-order=B" form:"path" json:"path" pg:",notnull,type:varchar(255),unique:uk_skill_path"`
+	// 文件内容 文本按 UTF-8 字节存
+	Content []byte `bson:"content" bun:",notnull,type:bytea" extensions:"x-order=C" json:"content,omitempty" pg:",notnull,type:bytea"`
+	// 内容类型
+	Mime string `bson:"mime" bun:",notnull,type:varchar(128)" extensions:"x-order=D" form:"mime" json:"mime,omitempty" pg:",notnull,type:varchar(128)"`
+	// 文件类型
+	//  * `text` - 文本
+	//  * `binary` - 二进制
+	Kind FileKind `bson:"kind" bun:",notnull,type:smallint" enums:"text,binary" extensions:"x-order=E" json:"kind,omitempty" pg:",notnull,type:smallint" swaggertype:"string"`
+	// 字节数
+	Size int64 `bson:"size" bun:",notnull,type:bigint" extensions:"x-order=F" form:"size" json:"size" pg:",notnull,type:bigint"`
+} // @name skillsFileBasic
+
+type Files []File
+
+// Creating function call to it's inner fields defined hooks
+func (z *File) Creating() error {
+	if z.IsZeroID() {
+		z.SetID(oid.NewID(oid.OtFile))
+	}
+
+	return z.DefaultModel.Creating()
+}
+func NewFileWithBasic(in FileBasic) *File {
+	obj := &File{
+		FileBasic: in,
+	}
+	return obj
+}
+func NewFileWithID(id any) *File {
+	obj := new(File)
+	_ = obj.SetID(id)
+	return obj
+}
+func (_ *File) IdentityLabel() string { return FileLabel }
+func (_ *File) IdentityModel() string { return FileTypID }
+func (_ *File) IdentityTable() string { return FileTable }
+func (_ *File) IdentityAlias() string { return FileAlias }
+
+type FileSet struct {
+	// 文件内容 文本按 UTF-8 字节存
+	Content *[]byte `extensions:"x-order=A" json:"content,omitempty"`
+	// 内容类型
+	Mime *string `extensions:"x-order=B" form:"mime" json:"mime,omitempty"`
+	// 文件类型
+	//  * `text` - 文本
+	//  * `binary` - 二进制
+	Kind *FileKind `enums:"text,binary" extensions:"x-order=C" json:"kind,omitempty" swaggertype:"string"`
+	// 字节数
+	Size *int64 `extensions:"x-order=D" json:"size"`
+} // @name skillsFileSet
+
+func (z *File) SetWith(o FileSet) {
+	if o.Content != nil {
+		z.LogChangeValue("content", z.Content, o.Content)
+		z.Content = *o.Content
+	}
+	if o.Mime != nil && z.Mime != *o.Mime {
+		z.LogChangeValue("mime", z.Mime, o.Mime)
+		z.Mime = *o.Mime
+	}
+	if o.Kind != nil {
+		z.LogChangeValue("kind", z.Kind, o.Kind)
+		z.Kind = *o.Kind
+	}
+	if o.Size != nil && z.Size != *o.Size {
+		z.LogChangeValue("size", z.Size, o.Size)
+		z.Size = *o.Size
+	}
+}

--- a/pkg/models/skills/skills_test.go
+++ b/pkg/models/skills/skills_test.go
@@ -1,0 +1,99 @@
+package skills
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidName(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"invoice", true},
+		{"pdf-processing", true},
+		{"a1-b2", true},
+		{"", false},
+		{"PDF", false},
+		{"-pdf", false},
+		{"pdf-", false},
+		{"pdf--x", false},
+		{"pdf processing", false},
+		{"pdf_processing", false},
+		{string(make([]byte, 65)), false},
+	}
+	for _, c := range cases {
+		if got := ValidName(c.name); got != c.want {
+			t.Errorf("ValidName(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestValidDescription(t *testing.T) {
+	ok := strings.Repeat("a", MaxDescriptionLen)
+	if !ValidDescription(ok) {
+		t.Errorf("length %d should be valid", MaxDescriptionLen)
+	}
+	if ValidDescription(ok + "a") {
+		t.Error("length over limit should be invalid")
+	}
+	// 中文字符按字符计，不按字节
+	cn := strings.Repeat("技", MaxDescriptionLen)
+	if !ValidDescription(cn) {
+		t.Error("multi-byte chars should count by rune")
+	}
+	if ValidDescription(cn + "技") {
+		t.Error("multi-byte over limit should be invalid")
+	}
+}
+
+func TestChannelMatches(t *testing.T) {
+	if ChannelNone.Matches("wecom") {
+		t.Error("ChannelNone should not match any channel")
+	}
+	if ChannelNone.Matches("") {
+		t.Error("ChannelNone should not match empty channel")
+	}
+	if !ChannelWecom.Matches("wecom") {
+		t.Error("ChannelWecom should match wecom")
+	}
+	if ChannelWecom.Matches("feishu") {
+		t.Error("ChannelWecom should not match feishu")
+	}
+	if ChannelWecom.Matches("") {
+		t.Error("ChannelWecom should not match web")
+	}
+	if !ChannelWeb.Matches("") {
+		t.Error("empty channel should map to web")
+	}
+	if (ChannelWeb | ChannelFeishu).Matches("feishu") == false {
+		t.Error("combined mask should match feishu")
+	}
+	if (ChannelWeb | ChannelFeishu).Matches("wecom") {
+		t.Error("combined mask should not match wecom")
+	}
+}
+
+func TestFrontmatter(t *testing.T) {
+	content := "---\nname: invoice\ndescription: 处理发票\n---\n\n正文"
+	name, desc, ok := Frontmatter(content)
+	if !ok || name != "invoice" || desc != "处理发票" {
+		t.Fatalf("Frontmatter = (%q, %q, %v)", name, desc, ok)
+	}
+	if _, _, ok := Frontmatter("plain markdown"); ok {
+		t.Error("plain markdown should not have frontmatter")
+	}
+}
+
+func TestValidateFrontmatter(t *testing.T) {
+	good := "---\nname: invoice\ndescription: 处理发票\n---\n\n正文"
+	if err := ValidateFrontmatter(good, "invoice", "处理发票"); err != nil {
+		t.Errorf("ValidateFrontmatter(good) = %v", err)
+	}
+	if err := ValidateFrontmatter("plain", "invoice", "d"); err != ErrFrontmatterMiss {
+		t.Errorf("missing frontmatter err = %v", err)
+	}
+	if err := ValidateFrontmatter("---\nname: other\ndescription: d\n---", "invoice", "d"); err != ErrNameMismatch {
+		t.Errorf("mismatch err = %v", err)
+	}
+}

--- a/pkg/models/skills/skills_x.go
+++ b/pkg/models/skills/skills_x.go
@@ -1,0 +1,101 @@
+package skills
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	// 开放标准约束：小写字母数字连字符，1-64 字符
+	nameRe = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+	ErrInvalidName     = errors.New("invalid skill name")
+	ErrDescriptionLong = errors.New("description too long")
+	ErrFrontmatterMiss = errors.New("missing skill frontmatter")
+	ErrNameMismatch    = errors.New("frontmatter name mismatch")
+)
+
+// MaxDescriptionLen 描述长度上限，与 DB 的 varchar(124) 一致（按字符计）
+const MaxDescriptionLen = 124
+
+// ValidName 校验开放标准要求的 name 格式
+func ValidName(name string) bool {
+	return len(name) > 0 && len(name) <= 64 && nameRe.MatchString(name)
+}
+
+// ValidDescription 校验描述长度（按字符计，varchar(124) 语义）
+func ValidDescription(s string) bool {
+	return utf8.RuneCountInString(s) <= MaxDescriptionLen
+}
+
+// Matches 判断位掩码是否包含指定频道名（web/wecom/feishu），None（0）表示未投放，
+// 不匹配任何频道（可见性由 owner 规则承担）。空频道名按 web 处理（HTTP 请求无频道上下文）。
+func (c Channel) Matches(channel string) bool {
+	if c == ChannelNone {
+		return false
+	}
+	var bit Channel
+	switch channel {
+	case "wecom":
+		bit = ChannelWecom
+	case "feishu":
+		bit = ChannelFeishu
+	default:
+		bit = ChannelWeb
+	}
+	return c&bit != 0
+}
+
+// Frontmatter 解析 SKILL.md 开头的 YAML frontmatter，返回 name 与 description。
+// 无 frontmatter 时返回 ok=false。
+func Frontmatter(content string) (name, desc string, ok bool) {
+	rest, ok := cutFrontmatter(content)
+	if !ok {
+		return "", "", false
+	}
+	var fm struct {
+		Name        string `yaml:"name"`
+		Description string `yaml:"description"`
+	}
+	if err := yaml.Unmarshal([]byte(rest), &fm); err != nil {
+		return "", "", false
+	}
+	return strings.TrimSpace(fm.Name), strings.TrimSpace(fm.Description), true
+}
+
+// ValidateFrontmatter 校验内容中的 frontmatter：存在且 name/description 非空，
+// name 与记录名一致且符合格式。
+func ValidateFrontmatter(content, name, desc string) error {
+	fmName, fmDesc, ok := Frontmatter(content)
+	if !ok {
+		return ErrFrontmatterMiss
+	}
+	if fmName == "" || fmDesc == "" {
+		return ErrFrontmatterMiss
+	}
+	if fmName != name {
+		return ErrNameMismatch
+	}
+	return nil
+}
+
+func cutFrontmatter(content string) (string, bool) {
+	s := strings.TrimPrefix(content, "\ufeff")
+	if !strings.HasPrefix(s, "---") {
+		return "", false
+	}
+	lines := strings.SplitN(s, "\n", 2)
+	if len(lines) < 2 {
+		return "", false
+	}
+	rest := lines[1]
+	idx := strings.Index(rest, "\n---")
+	if idx < 0 {
+		return "", false
+	}
+	return rest[:idx], true
+}

--- a/pkg/services/agent/skill_inject.go
+++ b/pkg/services/agent/skill_inject.go
@@ -1,0 +1,104 @@
+package agent
+
+import (
+	"context"
+	"strings"
+
+	"github.com/liut/morign/pkg/models/skills"
+	"github.com/liut/morign/pkg/settings"
+)
+
+// SkillStore 注入核心所需的最小存储接口
+type SkillStore interface {
+	TopRecent(ctx context.Context, limit int) (skills.Skills, error)
+	LoadForName(ctx context.Context, name string) (*skills.Skill, error)
+}
+
+// BuildSkillPrompt 组装注入 system prompt 的技能块：
+// 清单数量小于阈值时直注全文，否则仅注入 name+description 元数据。
+// 无可见技能时返回空字符串。
+func BuildSkillPrompt(ctx context.Context, sk SkillStore, requested []string) (string, error) {
+	names, err := resolveNames(ctx, sk, requested)
+	if err != nil || len(names) == 0 {
+		return "", err
+	}
+	var objs []*skills.Skill
+	for _, name := range names {
+		obj, err := sk.LoadForName(ctx, name)
+		if err != nil {
+			continue // 不可见或不存在，跳过
+		}
+		objs = append(objs, obj)
+	}
+	if len(objs) == 0 {
+		return "", nil
+	}
+	if len(objs) < settings.Current.SkillDirectThreshold {
+		var sb strings.Builder
+		sb.WriteString("\n\n# Skills\n")
+		for _, obj := range objs {
+			sb.WriteString("\n## Skill: ")
+			sb.WriteString(obj.Name)
+			sb.WriteString("\n")
+			sb.WriteString(obj.Content)
+		}
+		return sb.String(), nil
+	}
+	var sb strings.Builder
+	sb.WriteString("\n\n# Available Skills\n")
+	for _, obj := range objs {
+		sb.WriteString("- ")
+		sb.WriteString(obj.Name)
+		sb.WriteString(": ")
+		sb.WriteString(obj.Description)
+		sb.WriteString("\n")
+	}
+	sb.WriteString("可通过 skill_read 工具加载技能全文。\n")
+	return sb.String(), nil
+}
+
+// SkillPromptByCommand 指令命中时加载单个技能全文（等效 skill_read）。
+func SkillPromptByCommand(ctx context.Context, sk SkillStore, name string) (string, error) {
+	obj, err := sk.LoadForName(ctx, name)
+	if err != nil {
+		return "", err
+	}
+	var sb strings.Builder
+	sb.WriteString("\n## Skill: ")
+	sb.WriteString(obj.Name)
+	sb.WriteString("\n")
+	sb.WriteString(obj.Content)
+	return sb.String(), nil
+}
+
+func resolveNames(ctx context.Context, sk SkillStore, requested []string) ([]string, error) {
+	if len(requested) > 0 {
+		return dedupe(requested), nil
+	}
+	data, err := sk.TopRecent(ctx, settings.Current.SkillDefaultCount)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(data))
+	for _, obj := range data {
+		names = append(names, obj.Name)
+	}
+	return names, nil
+}
+
+func dedupe(names []string) []string {
+	seen := make(map[string]struct{}, len(names))
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if n == "" {
+			continue
+		}
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		out = append(out, n)
+	}
+	return out
+}

--- a/pkg/services/agent/skill_inject_test.go
+++ b/pkg/services/agent/skill_inject_test.go
@@ -1,0 +1,143 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/liut/morign/pkg/models/skills"
+	"github.com/liut/morign/pkg/settings"
+)
+
+type fakeSkillStore struct {
+	byName map[string]*skills.Skill
+	recent []skills.Skill
+}
+
+func (f *fakeSkillStore) TopRecent(ctx context.Context, limit int) (skills.Skills, error) {
+	if limit <= 0 || limit > len(f.recent) {
+		limit = len(f.recent)
+	}
+	return f.recent[:limit], nil
+}
+
+func (f *fakeSkillStore) LoadForName(ctx context.Context, name string) (*skills.Skill, error) {
+	obj, ok := f.byName[name]
+	if !ok {
+		return nil, errors.New("skill not found")
+	}
+	return obj, nil
+}
+
+func newFakeStore() *fakeSkillStore {
+	return &fakeSkillStore{
+		byName: map[string]*skills.Skill{},
+	}
+}
+
+func TestBuildSkillPromptDirectInjection(t *testing.T) {
+	settings.Current.SkillDirectThreshold = 3
+	f := newFakeStore()
+	f.byName["a"] = skillOf("a", "A", "content-a")
+	f.byName["b"] = skillOf("b", "B", "content-b")
+
+	out, err := BuildSkillPrompt(context.Background(), f, []string{"b", "a", "b", ""})
+	if err != nil {
+		t.Fatalf("BuildSkillPrompt: %v", err)
+	}
+	if !strings.Contains(out, "content-a") || !strings.Contains(out, "content-b") {
+		t.Errorf("direct injection missing full content: %q", out)
+	}
+	if strings.Contains(out, "skill_read") {
+		t.Errorf("direct injection should not contain tool hint: %q", out)
+	}
+}
+
+func TestBuildSkillPromptMetadata(t *testing.T) {
+	settings.Current.SkillDirectThreshold = 3
+	f := newFakeStore()
+	for _, name := range []string{"a", "b", "c", "d", "e"} {
+		f.byName[name] = skillOf(name, "desc-"+name, "content-"+name)
+	}
+
+	out, err := BuildSkillPrompt(context.Background(), f, []string{"a", "b", "c", "d", "e"})
+	if err != nil {
+		t.Fatalf("BuildSkillPrompt: %v", err)
+	}
+	for _, name := range []string{"a", "b", "c", "d", "e"} {
+		if !strings.Contains(out, "desc-"+name) {
+			t.Errorf("metadata missing %s: %q", name, out)
+		}
+		if strings.Contains(out, "content-"+name) {
+			t.Errorf("metadata leaked content for %s: %q", name, out)
+		}
+	}
+	if !strings.Contains(out, "skill_read") {
+		t.Errorf("metadata should hint skill_read: %q", out)
+	}
+}
+
+func TestBuildSkillPromptDefaults(t *testing.T) {
+	settings.Current.SkillDirectThreshold = 3
+	settings.Current.SkillDefaultCount = 2
+	f := newFakeStore()
+	f.byName["n1"] = skillOf("n1", "D1", "c1")
+	f.byName["n2"] = skillOf("n2", "D2", "c2")
+	f.recent = []skills.Skill{
+		{SkillBasic: skills.SkillBasic{Name: "n1"}},
+		{SkillBasic: skills.SkillBasic{Name: "n2"}},
+		{SkillBasic: skills.SkillBasic{Name: "n3"}},
+	}
+
+	out, err := BuildSkillPrompt(context.Background(), f, nil)
+	if err != nil {
+		t.Fatalf("BuildSkillPrompt: %v", err)
+	}
+	if !strings.Contains(out, "c1") || !strings.Contains(out, "c2") {
+		t.Errorf("default top-2 should inject full content: %q", out)
+	}
+}
+
+func TestBuildSkillPromptSkipsInvisible(t *testing.T) {
+	settings.Current.SkillDirectThreshold = 3
+	f := newFakeStore()
+	f.byName["a"] = skillOf("a", "A", "content-a")
+
+	out, err := BuildSkillPrompt(context.Background(), f, []string{"a", "missing"})
+	if err != nil {
+		t.Fatalf("BuildSkillPrompt: %v", err)
+	}
+	if !strings.Contains(out, "content-a") {
+		t.Errorf("visible skill should be injected: %q", out)
+	}
+}
+
+func TestBuildSkillPromptEmpty(t *testing.T) {
+	out, err := BuildSkillPrompt(context.Background(), newFakeStore(), nil)
+	if err != nil {
+		t.Fatalf("BuildSkillPrompt: %v", err)
+	}
+	if out != "" {
+		t.Errorf("empty store should return empty prompt, got %q", out)
+	}
+}
+
+func TestSkillPromptByCommand(t *testing.T) {
+	f := newFakeStore()
+	f.byName["invoice"] = skillOf("invoice", "D", "invoice-content")
+	out, err := SkillPromptByCommand(context.Background(), f, "invoice")
+	if err != nil {
+		t.Fatalf("SkillPromptByCommand: %v", err)
+	}
+	if !strings.Contains(out, "invoice-content") {
+		t.Errorf("command inject missing content: %q", out)
+	}
+	if _, err := SkillPromptByCommand(context.Background(), f, "nope"); err == nil {
+		t.Error("missing skill should return error")
+	}
+}
+
+func skillOf(name, desc, content string) *skills.Skill {
+	return &skills.Skill{SkillBasic: skills.SkillBasic{Name: name, Description: desc, Content: content}}
+}

--- a/pkg/services/stores/interfaces.go
+++ b/pkg/services/stores/interfaces.go
@@ -11,4 +11,5 @@ type Storage interface {
 	Convo() ConvoStore  // gened
 	State() StateStore
 	Capability() CapabilityStore // gened
+	Skill() SkillStore           // gened
 }

--- a/pkg/services/stores/skill_visible_test.go
+++ b/pkg/services/stores/skill_visible_test.go
@@ -1,0 +1,128 @@
+package stores
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cupogo/andvari/models/oid"
+	auth "github.com/liut/simpauth"
+
+	"github.com/liut/morign/pkg/models/mcps"
+	"github.com/liut/morign/pkg/models/skills"
+)
+
+func TestSkillVisibleCond(t *testing.T) {
+	cases := []struct {
+		name    string
+		channel string
+		user    bool
+		wantBit skills.Channel
+		wantOwn bool
+	}{
+		{"web no user", "", false, skills.ChannelWeb, false},
+		{"wecom no user", "wecom", false, skills.ChannelWecom, false},
+		{"feishu with user", "feishu", true, skills.ChannelFeishu, true},
+		{"web with user", "", true, skills.ChannelWeb, true},
+	}
+	for _, c := range cases {
+		ctx := context.Background()
+		if c.channel != "" {
+			ctx = mcps.ContextWithChannel(ctx, c.channel)
+		}
+		if c.user {
+			ctx = auth.ContextWithUser(ctx, &auth.User{
+				OID:  oid.NewID(oid.OtAccount).String(),
+				UID:  "u-" + c.name,
+				Name: c.name,
+			})
+		}
+		cond, args := skillVisibleCond(ctx)
+		if strings.Contains(cond, "channel = 0") {
+			t.Errorf("%s: cond should not treat channel=0 as public: %q", c.name, cond)
+		}
+		if !strings.Contains(cond, "channel & ? != 0") {
+			t.Errorf("%s: cond missing channel bit clause: %q", c.name, cond)
+		}
+		hasOwn := strings.Contains(cond, "owner = ?")
+		if hasOwn != c.wantOwn {
+			t.Errorf("%s: owner clause = %v, want %v", c.name, hasOwn, c.wantOwn)
+		}
+		if len(args) != 1+boolToInt(c.wantOwn) {
+			t.Errorf("%s: args len = %d", c.name, len(args))
+		}
+		if got, ok := args[0].(skills.Channel); !ok || got != c.wantBit {
+			t.Errorf("%s: channel bit = %v, want %v", c.name, args[0], c.wantBit)
+		}
+	}
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func TestSkillVisible(t *testing.T) {
+	ownerA := oid.NewID(oid.OtAccount).String()
+	ctxA := auth.ContextWithUser(mcps.ContextWithChannel(context.Background(), "wecom"), &auth.User{
+		OID: ownerA, UID: "a", Name: "A",
+	})
+	ctxB := auth.ContextWithUser(mcps.ContextWithChannel(context.Background(), "wecom"), &auth.User{
+		OID: oid.NewID(oid.OtAccount).String(), UID: "b", Name: "B",
+	})
+	ctxAnon := mcps.ContextWithChannel(context.Background(), "wecom")
+
+	cases := []struct {
+		name    string
+		ctx     context.Context
+		channel skills.Channel
+		want    bool
+	}{
+		{"owner visible unpublished", ctxA, skills.ChannelNone, true},
+		{"other cannot see unpublished", ctxB, skills.ChannelNone, false},
+		{"other sees published", ctxB, skills.ChannelWecom, true},
+		{"anonymous cannot see unpublished", ctxAnon, skills.ChannelNone, false},
+		{"anonymous sees published", ctxAnon, skills.ChannelWecom, true},
+	}
+	for _, c := range cases {
+		obj := &skills.Skill{SkillBasic: skills.SkillBasic{Channel: c.channel, Owner: oid.Cast(ownerA)}}
+		if got := skillVisible(c.ctx, obj); got != c.want {
+			t.Errorf("%s: skillVisible = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestDBBeforeCreateSkill(t *testing.T) {
+	user := &auth.User{OID: oid.NewID(oid.OtAccount).String(), UID: "u", Name: "u"}
+	ctx := auth.ContextWithUser(context.Background(), user)
+
+	// owner 为空 + 有用户：补上当前用户
+	obj := &skills.Skill{}
+	if err := dbBeforeCreateSkill(ctx, nil, obj); err != nil {
+		t.Fatalf("dbBeforeCreateSkill: %v", err)
+	}
+	if obj.Owner != oid.Cast(user.OID) {
+		t.Errorf("owner = %v, want %v", obj.Owner, user.OID)
+	}
+
+	// owner 为空 + 无用户：保持零值
+	obj2 := &skills.Skill{}
+	if err := dbBeforeCreateSkill(context.Background(), nil, obj2); err != nil {
+		t.Fatalf("dbBeforeCreateSkill no user: %v", err)
+	}
+	if !obj2.Owner.IsZero() {
+		t.Errorf("owner should stay zero without user, got %v", obj2.Owner)
+	}
+
+	// owner 已指定 + 有用户：不被覆盖（keeper 代建 / 导入可指定 owner）
+	initial := oid.NewID(oid.OtAccount)
+	obj3 := &skills.Skill{SkillBasic: skills.SkillBasic{Owner: initial}}
+	if err := dbBeforeCreateSkill(ctx, nil, obj3); err != nil {
+		t.Fatalf("dbBeforeCreateSkill with owner: %v", err)
+	}
+	if obj3.Owner != initial {
+		t.Errorf("owner should be preserved when set, got %v", obj3.Owner)
+	}
+}

--- a/pkg/services/stores/skills_gen.go
+++ b/pkg/services/stores/skills_gen.go
@@ -1,0 +1,138 @@
+// This file is generated - Do Not Edit.
+
+package stores
+
+import (
+	"context"
+
+	"github.com/liut/morign/pkg/models/skills"
+)
+
+// type File = skills.File
+// type Skill = skills.Skill
+
+func init() {
+	RegisterModel((*skills.Skill)(nil), (*skills.File)(nil))
+}
+
+type SkillStore interface {
+	SkillStoreX
+
+	ListSkill(ctx context.Context, spec *SkillSpec) (data skills.Skills, total int, err error)
+	GetSkill(ctx context.Context, id string) (obj *skills.Skill, err error)
+	CreateSkill(ctx context.Context, in skills.SkillBasic) (obj *skills.Skill, err error)
+	UpdateSkill(ctx context.Context, id string, in skills.SkillSet) error
+	DeleteSkill(ctx context.Context, id string) error
+
+	ListFile(ctx context.Context, spec *FileSpec) (data skills.Files, total int, err error)
+}
+
+type SkillSpec struct {
+	PageSpec
+	ModelSpec
+
+	// 技能名 全局唯一（小写字母数字连字符）
+	Name string `extensions:"x-order=A" form:"name" json:"name"`
+	// 可用频道 位掩码（0=未投放，仅创建者可见） (支持混合解码)
+	//  * `web`
+	//  * `wecom` - 企业微信
+	//  * `feishu` - 飞书
+	Channel string `extensions:"x-order=B" form:"channel" json:"channel" swaggertype:"string"`
+	// 创建者 uid
+	Owner string `extensions:"x-order=C" form:"owner" json:"owner"`
+	// 仅查看可见的
+	VisibleOnly bool `extensions:"x-order=D" form:"visible" json:"visible"`
+}
+
+func (spec *SkillSpec) Sift(q *ormQuery) *ormQuery {
+	q = spec.ModelSpec.Sift(q)
+	q, _ = siftMatch(q, "name", spec.Name, false)
+	if len(spec.Channel) > 0 {
+		var v skills.Channel
+		if err := v.Decode(spec.Channel); err == nil {
+			q = q.Where("?TableAlias.channel = ?", v)
+		}
+	}
+	q, _ = siftOID(q, "owner", spec.Owner, false)
+
+	return q
+}
+
+type FileSpec struct {
+	PageSpec
+	ModelSpec
+
+	// 所属技能 id
+	SkillID string `extensions:"x-order=A" form:"skillId" json:"skillId"`
+	// 资源文件相对路径 技能内唯一
+	Path string `extensions:"x-order=B" form:"path" json:"path"`
+}
+
+func (spec *FileSpec) Sift(q *ormQuery) *ormQuery {
+	q = spec.ModelSpec.Sift(q)
+	q, _ = siftOID(q, "skill_id", spec.SkillID, false)
+	q, _ = siftEqual(q, "path", spec.Path, false)
+
+	return q
+}
+
+type skillStore struct {
+	w *Wrap
+}
+
+func (s *skillStore) ListSkill(ctx context.Context, spec *SkillSpec) (data skills.Skills, total int, err error) {
+	total, err = s.w.db.ListModel(ctx, spec, &data)
+	return
+}
+func (s *skillStore) GetSkill(ctx context.Context, id string) (obj *skills.Skill, err error) {
+	obj = new(skills.Skill)
+	if err = dbGetWith(ctx, s.w.db, obj, "name", "=", id); err != nil && obj.SetID(id) {
+		err = dbGetWithPK(ctx, s.w.db, obj)
+	}
+
+	return
+}
+func (s *skillStore) CreateSkill(ctx context.Context, in skills.SkillBasic) (obj *skills.Skill, err error) {
+	err = s.w.db.RunInTx(ctx, nil, func(ctx context.Context, tx pgTx) (err error) {
+		obj = skills.NewSkillWithBasic(in)
+		if err = dbBeforeCreateSkill(ctx, tx, obj); err != nil {
+			return
+		}
+		if obj.Name == "" {
+			err = ErrEmptyKey
+			return
+		}
+		dbMetaUp(ctx, tx, obj)
+		err = dbInsert(ctx, tx, obj, "name")
+		return err
+	})
+	return
+}
+func (s *skillStore) UpdateSkill(ctx context.Context, id string, in skills.SkillSet) error {
+	exist := new(skills.Skill)
+	if err := dbGetWithPKID(ctx, s.w.db, exist, id); err != nil {
+		return err
+	}
+	exist.SetIsUpdate(true)
+	exist.SetWith(in)
+	dbMetaUp(ctx, s.w.db, exist)
+	return dbUpdate(ctx, s.w.db, exist)
+}
+func (s *skillStore) DeleteSkill(ctx context.Context, id string) error {
+	obj := new(skills.Skill)
+	if err := dbGetWithPKID(ctx, s.w.db, obj, id); err != nil {
+		return err
+	}
+	return s.w.db.RunInTx(ctx, nil, func(ctx context.Context, tx pgTx) (err error) {
+		if err = dbBeforeDeleteSkill(ctx, tx, obj); err != nil {
+			return
+		}
+		err = dbDeleteM(ctx, tx, s.w.db.Schema(), s.w.db.SchemaCrap(), obj)
+		return
+	})
+}
+
+func (s *skillStore) ListFile(ctx context.Context, spec *FileSpec) (data skills.Files, total int, err error) {
+	total, err = s.w.db.ListModel(ctx, spec, &data)
+	return
+}

--- a/pkg/services/stores/skills_integration_test.go
+++ b/pkg/services/stores/skills_integration_test.go
@@ -1,0 +1,168 @@
+//go:build integration
+
+package stores
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cupogo/andvari/models/oid"
+	auth "github.com/liut/simpauth"
+
+	"github.com/liut/morign/pkg/models/mcps"
+	"github.com/liut/morign/pkg/models/skills"
+)
+
+func TestIntegration_SkillVisibility(t *testing.T) {
+	sto := Sgt()
+	pid := os.Getpid()
+	userA := auth.User{OID: oid.NewID(oid.OtAccount).String(), UID: "skill-a", Name: "Skill A"}
+	userB := auth.User{OID: oid.NewID(oid.OtAccount).String(), UID: "skill-b", Name: "Skill B"}
+
+	names := []string{
+		fmt.Sprintf("a-none-%d", pid),
+		fmt.Sprintf("a-wecom-%d", pid),
+		fmt.Sprintf("b-web-%d", pid),
+	}
+	skillsList := []skills.SkillBasic{
+		{Name: names[0], Description: "A private", Content: "---\nname: " + names[0] + "\ndescription: A private\n---\nbody",
+			Channel: skills.ChannelNone, Owner: oid.Cast(userA.OID)},
+		{Name: names[1], Description: "A wecom", Content: "---\nname: " + names[1] + "\ndescription: A wecom\n---\nbody",
+			Channel: skills.ChannelWecom, Owner: oid.Cast(userA.OID)},
+		{Name: names[2], Description: "B web", Content: "---\nname: " + names[2] + "\ndescription: B web\n---\nbody",
+			Channel: skills.ChannelWeb, Owner: oid.Cast(userB.OID)},
+	}
+	for _, in := range skillsList {
+		if _, err := sto.Skill().CreateSkill(context.Background(), in); err != nil {
+			t.Fatalf("CreateSkill(%s) failed: %v", in.Name, err)
+		}
+	}
+	t.Cleanup(func() {
+		for _, in := range skillsList {
+			if obj, err := sto.Skill().GetSkill(context.Background(), in.Name); err == nil && obj != nil {
+				_ = sto.Skill().DeleteSkill(context.Background(), obj.ID.String())
+			}
+		}
+	})
+
+	ctxA := auth.ContextWithUser(mcps.ContextWithChannel(context.Background(), "wecom"), &userA)
+	ctxB := auth.ContextWithUser(mcps.ContextWithChannel(context.Background(), "wecom"), &userB)
+
+	// A 在 wecom 可见：自己的未投放 + 自己的 wecom 投放；看不到 B 的 web 投放
+	listA, _, err := sto.Skill().ListVisibleMetadata(ctxA, &SkillSpec{})
+	if err != nil {
+		t.Fatalf("ListVisibleMetadata A failed: %v", err)
+	}
+	if got := countSkills(listA, names); got != 2 {
+		t.Errorf("A visible count = %d, want 2 (%v)", got, names)
+	}
+	// 列表不含 content
+	for _, sk := range listA {
+		if sk.Content != "" {
+			t.Errorf("metadata list leaked content for %s", sk.Name)
+		}
+	}
+
+	// B 在 wecom 可见：A 投放的 wecom + 自己的 web；看不到 A 的未投放（Covers AE4）
+	listB, _, err := sto.Skill().ListVisibleMetadata(ctxB, &SkillSpec{})
+	if err != nil {
+		t.Fatalf("ListVisibleMetadata B failed: %v", err)
+	}
+	if got := countSkills(listB, names); got != 2 {
+		t.Errorf("B visible count = %d, want 2", got)
+	}
+	for _, sk := range listB {
+		if sk.Name == names[0] {
+			t.Errorf("B should not see A's unpublished skill %s", names[0])
+		}
+	}
+
+	// LoadForName 越权按 not found（不泄露存在性）
+	if _, err := sto.Skill().LoadForName(ctxB, names[0]); !errors.Is(err, ErrSkillNotFound) {
+		t.Errorf("B LoadForName(A private) err = %v, want ErrSkillNotFound", err)
+	}
+	// 投放的 wecom 对频道内其他用户可见
+	if _, err := sto.Skill().LoadForName(ctxB, names[1]); err != nil {
+		t.Errorf("B LoadForName(A wecom) err = %v, want nil", err)
+	}
+	// 自己的可见，且含全文
+	got, err := sto.Skill().LoadForName(ctxA, names[1])
+	if err != nil {
+		t.Fatalf("A LoadForName failed: %v", err)
+	}
+	if got.Content == "" {
+		t.Error("LoadForName should return full content")
+	}
+
+	// ListVisibleMetadata 强制可见性：即便 spec.VisibleOnly 传 false 也不会绕过
+	specB := &SkillSpec{}
+	listB2, _, err := sto.Skill().ListVisibleMetadata(ctxB, specB)
+	if err != nil {
+		t.Fatalf("ListVisibleMetadata B2 failed: %v", err)
+	}
+	if got := countSkills(listB2, names); got != 2 {
+		t.Errorf("B2 visible count = %d, want 2", got)
+	}
+
+	// 管理端 ListSkill 不设 VisibleOnly：不套可见性，可见全部（含未投放与跨频道）
+	listAll, _, err := sto.Skill().ListSkill(ctxB, &SkillSpec{})
+	if err != nil {
+		t.Fatalf("ListSkill failed: %v", err)
+	}
+	if got := countSkills(listAll, names); got != 3 {
+		t.Errorf("admin list count = %d, want 3", got)
+	}
+}
+
+func TestIntegration_SkillTopRecent(t *testing.T) {
+	sto := Sgt()
+	pid := os.Getpid()
+	owner := oid.NewID(oid.OtAccount).String()
+	user := auth.User{OID: owner, UID: "skill-top", Name: "Skill Top"}
+	ctx := auth.ContextWithUser(context.Background(), &user)
+
+	var created []string
+	for i := 0; i < 5; i++ {
+		name := fmt.Sprintf("top-%d-%d", i, pid)
+		created = append(created, name)
+		if _, err := sto.Skill().CreateSkill(ctx, skills.SkillBasic{
+			Name: name, Description: name, Content: "body",
+			Channel: skills.ChannelNone, Owner: oid.Cast(owner),
+		}); err != nil {
+			t.Fatalf("CreateSkill(%s) failed: %v", name, err)
+		}
+	}
+	t.Cleanup(func() {
+		for _, name := range created {
+			if obj, err := sto.Skill().GetSkill(context.Background(), name); err == nil && obj != nil {
+				_ = sto.Skill().DeleteSkill(context.Background(), obj.ID.String())
+			}
+		}
+	})
+
+	data, err := sto.Skill().TopRecent(ctx, 3)
+	if err != nil {
+		t.Fatalf("TopRecent failed: %v", err)
+	}
+	if len(data) != 3 {
+		t.Errorf("TopRecent len = %d, want 3", len(data))
+	}
+	if data[0].Name != created[4] {
+		t.Errorf("TopRecent[0] = %s, want newest %s", data[0].Name, created[4])
+	}
+}
+
+func countSkills(data skills.Skills, names []string) int {
+	n := 0
+	for _, sk := range data {
+		for _, name := range names {
+			if sk.Name == name {
+				n++
+			}
+		}
+	}
+	return n
+}

--- a/pkg/services/stores/skills_x.go
+++ b/pkg/services/stores/skills_x.go
@@ -1,0 +1,302 @@
+package stores
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/cupogo/andvari/models/oid"
+	"github.com/cupogo/andvari/stores/pgx"
+
+	"github.com/liut/morign/pkg/models/mcps"
+	"github.com/liut/morign/pkg/models/skills"
+)
+
+// SkillStoreX 技能存储扩展接口
+type SkillStoreX interface {
+	ListVisibleMetadata(ctx context.Context, spec *SkillSpec) (data skills.Skills, total int, err error)
+	TopRecent(ctx context.Context, limit int) (data skills.Skills, err error)
+	LoadForName(ctx context.Context, name string) (*skills.Skill, error)
+	CreateSkillWithFiles(ctx context.Context, in skills.SkillBasic, files map[string]string) (obj *skills.Skill, err error)
+	UpdateSkillWithFiles(ctx context.Context, id string, set skills.SkillSet, files map[string]string) error
+	ListFileNames(ctx context.Context, name string) (skills.Files, error)
+	ReadFile(ctx context.Context, name, path string) (*skills.File, error)
+}
+
+var ErrSkillNotFound = errors.New("skill not found")
+var ErrFileNotFound = errors.New("file not found")
+
+const (
+	maxSkillFileSize   = 1 << 20  // 单文件大小上限 1MB
+	maxSkillBundleSize = 10 << 20 // 单技能资源总量上限 10MB
+)
+
+// channelBit 返回当前上下文的频道位掩码；空频道名按 web 处理（HTTP 请求无频道上下文）。
+func channelBit(ctx context.Context) skills.Channel {
+	switch mcps.ChannelFromContext(ctx) {
+	case "wecom":
+		return skills.ChannelWecom
+	case "feishu":
+		return skills.ChannelFeishu
+	default:
+		return skills.ChannelWeb
+	}
+}
+
+// skillVisibleCond 可见性条件：Channel 显式投放的频道 或 当前用户创建。
+// 未投放（0）仅创建者可见。
+func skillVisibleCond(ctx context.Context) (string, []any) {
+	conds := []string{"channel & ? != 0"}
+	args := []any{channelBit(ctx)}
+	if user, ok := UserFromContext(ctx); ok {
+		conds = append(conds, "owner = ?")
+		args = append(args, oid.Cast(user.OID))
+	}
+	return "(" + strings.Join(conds, " OR ") + ")", args
+}
+
+// skillVisible 与 skillVisibleCond 同规则：显式投放的频道 或 当前用户创建。
+func skillVisible(ctx context.Context, obj *skills.Skill) bool {
+	if user, ok := UserFromContext(ctx); ok && obj.Owner == oid.Cast(user.OID) {
+		return true
+	}
+	return obj.Channel&channelBit(ctx) != 0
+}
+
+// SiftX 按 spec.VisibleOnly 注入可见性过滤；始终裁剪元数据并默认时间排序。
+func (spec *SkillSpec) SiftX(ctx context.Context, q *ormQuery) *ormQuery {
+	if spec.VisibleOnly {
+		cond, args := skillVisibleCond(ctx)
+		q = q.Where(cond, args...)
+	}
+	q = q.ExcludeColumn("content")
+	if spec.Sort == "" {
+		spec.Sort = "created DESC"
+	}
+	return q
+}
+
+// ListVisibleMetadata 返回可见范围内的技能元数据（不含 SKILL.md 全文）。
+// VisibleOnly 由本方法强制开启，避免客户端以 visible=false 绕过可见性；管理端 ListSkill 不受限。
+func (s *skillStore) ListVisibleMetadata(ctx context.Context, spec *SkillSpec) (data skills.Skills, total int, err error) {
+	spec.VisibleOnly = true
+	total, err = s.w.db.ListModel(ctx, spec, &data)
+	return
+}
+
+// TopRecent 返回可见技能中按创建时间最新的前 limit 条（元数据）。
+func (s *skillStore) TopRecent(ctx context.Context, limit int) (data skills.Skills, err error) {
+	spec := &SkillSpec{}
+	if limit > 0 {
+		spec.Limit = limit
+	}
+	data, _, err = s.ListVisibleMetadata(ctx, spec)
+	return
+}
+
+// LoadForName 加载指定技能（含全文）。name 全局唯一，先按名加载（dbGetWith）、
+// 再在 Go 层校验可见性；越权或不存在统一返回 ErrSkillNotFound（不泄露存在性）。
+// 工具、指令注入与详情 API 共用此加载器。
+func (s *skillStore) LoadForName(ctx context.Context, name string) (*skills.Skill, error) {
+	obj := new(skills.Skill)
+	err := dbGetWith(ctx, s.w.db, obj, "name", "=", name)
+	if err != nil {
+		if errors.Is(err, ErrNoRows) || errors.Is(err, ErrNotFound) {
+			return nil, errors.Join(ErrSkillNotFound, err)
+		}
+		return nil, err
+	}
+	if !skillVisible(ctx, obj) {
+		return nil, ErrSkillNotFound
+	}
+	return obj, nil
+}
+func dbBeforeCreateSkill(ctx context.Context, db ormDB, obj *skills.Skill) error {
+	if obj.Owner.IsZero() {
+		user, ok := UserFromContext(ctx)
+		if ok {
+			obj.Owner = oid.Cast(user.OID)
+		}
+	}
+
+	return nil
+}
+
+// SiftX 文件清单查询始终裁剪内容列，避免加载 bytea。
+func (spec *FileSpec) SiftX(ctx context.Context, q *ormQuery) *ormQuery {
+	return q.ExcludeColumn("content")
+}
+
+// ListFileNames 返回指定可见技能的资源文件清单（不含内容）。
+func (s *skillStore) ListFileNames(ctx context.Context, name string) (skills.Files, error) {
+	obj, err := s.LoadForName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	data, _, err := s.ListFile(ctx, &FileSpec{SkillID: obj.ID.String()})
+	return data, err
+}
+
+// ReadFile 返回指定可见技能的单资源文件（含内容）。
+func (s *skillStore) ReadFile(ctx context.Context, name, path string) (*skills.File, error) {
+	obj, err := s.LoadForName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	file := new(skills.File)
+	err = s.w.db.NewSelect().Model(file).
+		Where("skill_id = ?", obj.ID).
+		Where("path = ?", path).
+		Limit(1).Scan(ctx)
+	if err != nil {
+		if errors.Is(err, ErrNoRows) || errors.Is(err, ErrNotFound) {
+			return nil, ErrFileNotFound
+		}
+		return nil, err
+	}
+	return file, nil
+}
+
+// CreateSkillWithFiles 创建技能并在同一事务内写入资源文件（与生成 CreateSkill 同逻辑，扩为 bundle 原子写）。
+func (s *skillStore) CreateSkillWithFiles(ctx context.Context, in skills.SkillBasic, files map[string]string) (obj *skills.Skill, err error) {
+	if err = checkSkillFiles(files); err != nil {
+		return nil, err
+	}
+	err = s.w.db.RunInTx(ctx, nil, func(ctx context.Context, tx pgTx) (err error) {
+		obj = skills.NewSkillWithBasic(in)
+		if err = dbBeforeCreateSkill(ctx, tx, obj); err != nil {
+			return
+		}
+		if obj.Name == "" {
+			err = ErrEmptyKey
+			return
+		}
+		dbMetaUp(ctx, tx, obj)
+		if err = dbInsert(ctx, tx, obj, "name"); err != nil {
+			return
+		}
+		return upsertSkillFiles(ctx, tx, obj.ID, files)
+	})
+	return
+}
+
+// UpdateSkillWithFiles 更新技能并在同一事务内按 bundle 替换资源文件；files 为 nil 时保留现有文件。
+func (s *skillStore) UpdateSkillWithFiles(ctx context.Context, id string, set skills.SkillSet, files map[string]string) error {
+	if files != nil {
+		if err := checkSkillFiles(files); err != nil {
+			return err
+		}
+	}
+	return s.w.db.RunInTx(ctx, nil, func(ctx context.Context, tx pgTx) (err error) {
+		exist := new(skills.Skill)
+		if err = dbGetWithPKID(ctx, tx, exist, id); err != nil {
+			return
+		}
+		exist.SetIsUpdate(true)
+		exist.SetWith(set)
+		dbMetaUp(ctx, tx, exist)
+		if err = dbUpdate(ctx, tx, exist); err != nil {
+			return
+		}
+		if files != nil {
+			return upsertSkillFiles(ctx, tx, exist.ID, files)
+		}
+		return nil
+	})
+}
+
+// dbBeforeDeleteSkill 技能删除前清理资源文件（由生成 DeleteSkill 在事务内调用）。
+func dbBeforeDeleteSkill(ctx context.Context, db ormDB, obj *skills.Skill) error {
+	_, err := db.NewDelete().Model((*skills.File)(nil)).Where("skill_id = ?", obj.ID).Exec(ctx)
+	return err
+}
+
+// upsertSkillFiles 按 (skill_id, path) 复合键 upsert，并删除已不在 bundle 中的文件。
+func upsertSkillFiles(ctx context.Context, db ormDB, skillID oid.OID, files map[string]string) error {
+	paths := make([]string, 0, len(files))
+	for path, content := range files {
+		paths = append(paths, path)
+		obj := skills.NewFileWithBasic(skills.FileBasic{
+			SkillID: skillID,
+			Path:    path,
+			Content: []byte(content),
+			Mime:    fileMimeFor(path),
+			Kind:    detectFileKind(path, []byte(content)),
+			Size:    int64(len(content)),
+		})
+		if err := obj.Creating(); err != nil {
+			return err
+		}
+		if _, err := db.NewInsert().Model(obj).On(
+			"CONFLICT (skill_id, path) DO UPDATE SET content = EXCLUDED.content, mime = EXCLUDED.mime, kind = EXCLUDED.kind, size = EXCLUDED.size, updated = EXCLUDED.updated",
+		).Exec(ctx); err != nil {
+			return err
+		}
+	}
+	q := db.NewDelete().Model((*skills.File)(nil)).Where("skill_id = ?", skillID)
+	if len(paths) > 0 {
+		q.Where("path NOT IN (?)", pgx.In(paths))
+	}
+	_, err := q.Exec(ctx)
+	return err
+}
+
+func checkSkillFiles(files map[string]string) error {
+	var total int64
+	for path, content := range files {
+		if path == "" {
+			return errors.New("empty file path")
+		}
+		size := int64(len(content))
+		if size > maxSkillFileSize {
+			return fmt.Errorf("file %s exceeds max size %d bytes", path, maxSkillFileSize)
+		}
+		total += size
+	}
+	if total > maxSkillBundleSize {
+		return fmt.Errorf("skill bundle exceeds max size %d bytes", maxSkillBundleSize)
+	}
+	return nil
+}
+
+var binaryExts = map[string]bool{
+	".png": true, ".jpg": true, ".jpeg": true, ".gif": true, ".webp": true, ".ico": true, ".svg": true,
+	".pdf": true, ".zip": true, ".gz": true, ".tar": true, ".7z": true,
+	".woff": true, ".woff2": true, ".ttf": true, ".otf": true,
+	".mp3": true, ".mp4": true, ".wav": true, ".mov": true,
+}
+
+func detectFileKind(path string, content []byte) skills.FileKind {
+	if binaryExts[strings.ToLower(pathExt(path))] {
+		return skills.FileKindBinary
+	}
+	if bytes.IndexByte(content, 0) >= 0 || !utf8.Valid(content) {
+		return skills.FileKindBinary
+	}
+	return skills.FileKindText
+}
+
+var mimeByExt = map[string]string{
+	".md": "text/markdown", ".txt": "text/plain", ".py": "text/x-python",
+	".js": "application/javascript", ".ts": "application/typescript", ".json": "application/json",
+	".yaml": "application/yaml", ".yml": "application/yaml", ".sh": "text/x-shellscript",
+	".go": "text/x-go", ".html": "text/html", ".css": "text/css", ".sql": "text/plain",
+	".toml": "application/toml", ".xml": "application/xml", ".svg": "image/svg+xml",
+}
+
+func fileMimeFor(path string) string {
+	if m, ok := mimeByExt[strings.ToLower(pathExt(path))]; ok {
+		return m
+	}
+	return "application/octet-stream"
+}
+
+func pathExt(path string) string {
+	if i := strings.LastIndexByte(path, '.'); i >= 0 {
+		return path[i:]
+	}
+	return ""
+}

--- a/pkg/services/stores/wrap.go
+++ b/pkg/services/stores/wrap.go
@@ -33,9 +33,10 @@ type StringsDiff = pgx.StringsDiff
 var (
 	pgList = pgx.List
 
-	ErrNoRows   = pgx.ErrNoRows
-	ErrNotFound = pgx.ErrNotFound
-	ErrEmptyKey = pgx.ErrEmptyKey
+	ErrNoRows    = pgx.ErrNoRows
+	ErrNotFound  = pgx.ErrNotFound
+	ErrEmptyKey  = pgx.ErrEmptyKey
+	ErrDuplicate = pgx.ErrDuplicate
 
 	dbGet           = pgx.Get
 	dbFirst         = pgx.First
@@ -106,6 +107,7 @@ type Wrap struct {
 	mcpStore        *mcpStore        // gened
 	convoStore      *convoStore      // gened
 	capabilityStore *capabilityStore // gened
+	skillStore      *skillStore      // gened
 }
 
 // NewWithDB return new instance of Wrap
@@ -121,6 +123,7 @@ func NewWithDB(db *pgx.DB) *Wrap {
 	w.mcpStore = &mcpStore{w: w}               // gened
 	w.convoStore = &convoStore{w: w}           // gened
 	w.capabilityStore = &capabilityStore{w: w} // gened
+	w.skillStore = &skillStore{w: w}           // gened
 
 	// more member stores
 	return w
@@ -186,3 +189,4 @@ func (w *Wrap) MCP() MCPStore               { return w.mcpStore }   // MCP gened
 func (w *Wrap) Convo() ConvoStore           { return w.convoStore } // Convo gened
 func (w *Wrap) State() StateStore           { return w.stateStore }
 func (w *Wrap) Capability() CapabilityStore { return w.capabilityStore } // Capability gened
+func (w *Wrap) Skill() SkillStore           { return w.skillStore }      // Skill gened

--- a/pkg/services/tools/registry.go
+++ b/pkg/services/tools/registry.go
@@ -30,6 +30,7 @@ type channelToolSet struct {
 type Registry struct {
 	tools    []mcps.ToolDescriptor
 	invokers map[string]Invoker
+	skills   SkillToolStore
 
 	// 受限工具列表（需要 keeper 角色）
 	privTools []mcps.ToolDescriptor
@@ -147,6 +148,17 @@ func (r *Registry) initTools(sto stores.Storage) {
 		r.invokers[ToolNameMemoryRecall] = sto.Convo().InvokerForMemoryRecall()
 		r.invokers[ToolNameMemoryStore] = sto.Convo().InvokerForMemoryStore()
 		r.invokers[ToolNameMemoryForget] = sto.Convo().InvokerForMemoryForget()
+
+		// 技能工具
+		r.skills = sto.Skill()
+		r.tools = append(r.tools,
+			skillListDescriptor, skillReadDescriptor,
+			skillFileListDescriptor, skillFileReadDescriptor,
+		)
+		r.invokers[ToolNameSkillList] = r.callSkillList
+		r.invokers[ToolNameSkillRead] = r.callSkillRead
+		r.invokers[ToolNameSkillFileList] = r.callSkillFileList
+		r.invokers[ToolNameSkillFileRead] = r.callSkillFileRead
 
 		// Capability tools - type assert to get X interface
 		ctx := context.Background()

--- a/pkg/services/tools/skills.go
+++ b/pkg/services/tools/skills.go
@@ -1,0 +1,188 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/liut/morign/pkg/models/mcps"
+	"github.com/liut/morign/pkg/models/skills"
+	"github.com/liut/morign/pkg/services/stores"
+)
+
+const (
+	ToolNameSkillList     = "skill_list"
+	ToolNameSkillRead     = "skill_read"
+	ToolNameSkillFileList = "skill_file_list"
+	ToolNameSkillFileRead = "skill_file_read"
+)
+
+// SkillToolStore 技能工具所需的最小存储接口
+type SkillToolStore interface {
+	ListVisibleMetadata(ctx context.Context, spec *stores.SkillSpec) (skills.Skills, int, error)
+	LoadForName(ctx context.Context, name string) (*skills.Skill, error)
+	ListFileNames(ctx context.Context, name string) (skills.Files, error)
+	ReadFile(ctx context.Context, name, path string) (*skills.File, error)
+}
+
+var (
+	skillListDescriptor = mcps.ToolDescriptor{
+		Name:        ToolNameSkillList,
+		Description: "List available skills (name and description) for discovery. Call when no listed skill matches the task.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"limit": map[string]any{
+					"type":        "number",
+					"description": "max items to return, default 10, max 50",
+					"default":     10,
+					"minimum":     1,
+					"maximum":     50,
+				},
+			},
+		},
+	}
+
+	skillReadDescriptor = mcps.ToolDescriptor{
+		Name:        ToolNameSkillRead,
+		Description: "Load a skill's SKILL.md instructions by name. Call when an available skill is relevant to the current task.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]any{
+					"type":        "string",
+					"description": "skill name",
+				},
+			},
+			"required": []string{"name"},
+		},
+	}
+
+	skillFileListDescriptor = mcps.ToolDescriptor{
+		Name:        ToolNameSkillFileList,
+		Description: "List a skill's resource file names (scripts, references, assets) by skill name.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]any{
+					"type":        "string",
+					"description": "skill name",
+				},
+			},
+			"required": []string{"name"},
+		},
+	}
+
+	skillFileReadDescriptor = mcps.ToolDescriptor{
+		Name:        ToolNameSkillFileRead,
+		Description: "Read a skill resource file content by skill name and file path.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]any{
+					"type":        "string",
+					"description": "skill name",
+				},
+				"file": map[string]any{
+					"type":        "string",
+					"description": "resource file path within the skill",
+				},
+			},
+			"required": []string{"name", "file"},
+		},
+	}
+)
+
+// callSkillList 返回可见技能的紧凑元数据列表，默认取前 10 条。
+func (r *Registry) callSkillList(ctx context.Context, args map[string]any) (map[string]any, error) {
+	if r.skills == nil {
+		return mcps.BuildToolErrorResult("skill store unavailable"), nil
+	}
+	limit, _, _ := mcps.IntArg(args, "limit")
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 50 {
+		limit = 50
+	}
+	spec := &stores.SkillSpec{}
+	spec.Limit = limit
+	data, _, err := r.skills.ListVisibleMetadata(ctx, spec)
+	if err != nil {
+		return mcps.BuildToolErrorResult("list skills failed"), nil
+	}
+	var sb strings.Builder
+	for _, obj := range data {
+		sb.WriteString("- ")
+		sb.WriteString(obj.Name)
+		sb.WriteString(": ")
+		sb.WriteString(obj.Description)
+		sb.WriteString("\n")
+	}
+	return mcps.BuildToolSuccessResult(strings.TrimSuffix(sb.String(), "\n")), nil
+}
+
+// callSkillRead 返回指定技能 SKILL.md 指令全文，可见性由 LoadForName 统一校验。
+func (r *Registry) callSkillRead(ctx context.Context, args map[string]any) (map[string]any, error) {
+	if r.skills == nil {
+		return mcps.BuildToolErrorResult("skill store unavailable"), nil
+	}
+	name := mcps.StringArg(args, "name")
+	if name == "" {
+		return mcps.BuildToolErrorResult("missing required argument: name"), nil
+	}
+	obj, err := r.skills.LoadForName(ctx, name)
+	if err != nil {
+		return mcps.BuildToolErrorResult("skill not found or not visible"), nil
+	}
+	return mcps.BuildToolSuccessResult(fmt.Sprintf("# Skill: %s\n%s", obj.Name, obj.Content)), nil
+}
+
+// callSkillFileList 返回指定技能的资源文件清单（path/mime/size，不含内容）。
+func (r *Registry) callSkillFileList(ctx context.Context, args map[string]any) (map[string]any, error) {
+	if r.skills == nil {
+		return mcps.BuildToolErrorResult("skill store unavailable"), nil
+	}
+	name := mcps.StringArg(args, "name")
+	if name == "" {
+		return mcps.BuildToolErrorResult("missing required argument: name"), nil
+	}
+	data, err := r.skills.ListFileNames(ctx, name)
+	if err != nil {
+		return mcps.BuildToolErrorResult("skill not found or not visible"), nil
+	}
+	if len(data) == 0 {
+		return mcps.BuildToolSuccessResult("(no resource files)"), nil
+	}
+	sort.Slice(data, func(i, j int) bool { return data[i].Path < data[j].Path })
+	var sb strings.Builder
+	for _, f := range data {
+		fmt.Fprintf(&sb, "%s (%s, %d bytes)\n", f.Path, f.Mime, f.Size)
+	}
+	return mcps.BuildToolSuccessResult(strings.TrimSuffix(sb.String(), "\n")), nil
+}
+
+// callSkillFileRead 返回指定资源文件内容；binary 文件仅返回元数据，不内联内容。
+func (r *Registry) callSkillFileRead(ctx context.Context, args map[string]any) (map[string]any, error) {
+	if r.skills == nil {
+		return mcps.BuildToolErrorResult("skill store unavailable"), nil
+	}
+	name := mcps.StringArg(args, "name")
+	file := mcps.StringArg(args, "file")
+	if name == "" || file == "" {
+		return mcps.BuildToolErrorResult("missing required argument: name or file"), nil
+	}
+	obj, err := r.skills.ReadFile(ctx, name, file)
+	if err != nil {
+		if errors.Is(err, stores.ErrFileNotFound) {
+			return mcps.BuildToolErrorResult("resource not found: " + file), nil
+		}
+		return mcps.BuildToolErrorResult("skill not found or not visible"), nil
+	}
+	if obj.Kind == skills.FileKindBinary {
+		return mcps.BuildToolSuccessResult(fmt.Sprintf("%s: binary resource (%s, %d bytes), content not inlined", file, obj.Mime, obj.Size)), nil
+	}
+	return mcps.BuildToolSuccessResult(string(obj.Content)), nil
+}

--- a/pkg/services/tools/skills_test.go
+++ b/pkg/services/tools/skills_test.go
@@ -1,0 +1,206 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/liut/morign/pkg/models/skills"
+	"github.com/liut/morign/pkg/services/stores"
+)
+
+type fakeSkillStore struct {
+	byName map[string]*skills.Skill
+	files  map[string]skills.Files
+}
+
+func (f *fakeSkillStore) ListVisibleMetadata(ctx context.Context, spec *stores.SkillSpec) (skills.Skills, int, error) {
+	var data skills.Skills
+	for _, obj := range f.byName {
+		data = append(data, *obj)
+	}
+	if spec.Limit > 0 && len(data) > spec.Limit {
+		data = data[:spec.Limit]
+	}
+	return data, len(data), nil
+}
+
+func (f *fakeSkillStore) LoadForName(ctx context.Context, name string) (*skills.Skill, error) {
+	obj, ok := f.byName[name]
+	if !ok {
+		return nil, errors.New("skill not found")
+	}
+	return obj, nil
+}
+
+func (f *fakeSkillStore) ListFileNames(ctx context.Context, name string) (skills.Files, error) {
+	if _, ok := f.byName[name]; !ok {
+		return nil, errors.New("skill not found")
+	}
+	return f.files[name], nil
+}
+
+func (f *fakeSkillStore) ReadFile(ctx context.Context, name, path string) (*skills.File, error) {
+	if _, ok := f.byName[name]; !ok {
+		return nil, errors.New("skill not found")
+	}
+	for i := range f.files[name] {
+		if f.files[name][i].Path == path {
+			return &f.files[name][i], nil
+		}
+	}
+	return nil, errors.New("file not found")
+}
+
+func skillFor(name string) *skills.Skill {
+	return &skills.Skill{SkillBasic: skills.SkillBasic{
+		Name: name, Description: "desc", Content: "content-" + name,
+	}}
+}
+
+func fileRow(path, content string, kind skills.FileKind) skills.File {
+	return skills.File{FileBasic: skills.FileBasic{
+		Path:    path,
+		Content: []byte(content),
+		Mime:    "text/plain",
+		Kind:    kind,
+		Size:    int64(len(content)),
+	}}
+}
+
+func TestCallSkillList(t *testing.T) {
+	r := &Registry{skills: &fakeSkillStore{byName: map[string]*skills.Skill{
+		"a": skillFor("a"),
+		"b": skillFor("b"),
+	}}}
+	res, err := r.callSkillList(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("callSkillList: %v", err)
+	}
+	text := resultText(res)
+	if !strings.Contains(text, "- a:") || !strings.Contains(text, "- b:") {
+		t.Errorf("skill_list should list names with descriptions: %q", text)
+	}
+	res, _ = r.callSkillList(context.Background(), map[string]any{"limit": 1})
+	if strings.Count(resultText(res), "\n") != 0 {
+		t.Errorf("limit 1 should return single line: %q", resultText(res))
+	}
+	if res, _ := (&Registry{}).callSkillList(context.Background(), nil); !resultError(res) {
+		t.Error("nil store should error")
+	}
+}
+
+func TestCallSkillRead(t *testing.T) {
+	r := &Registry{skills: &fakeSkillStore{byName: map[string]*skills.Skill{
+		"invoice": skillFor("invoice"),
+	}}}
+	res, err := r.callSkillRead(context.Background(), map[string]any{"name": "invoice"})
+	if err != nil {
+		t.Fatalf("callSkillRead: %v", err)
+	}
+	text := resultText(res)
+	if !strings.Contains(text, "content-invoice") {
+		t.Errorf("skill_read should return SKILL.md content: %q", text)
+	}
+	if strings.Contains(text, "scripts/a.py") {
+		t.Errorf("skill_read should not include file list: %q", text)
+	}
+}
+
+func TestCallSkillReadErrors(t *testing.T) {
+	r := &Registry{skills: &fakeSkillStore{byName: map[string]*skills.Skill{
+		"invoice": skillFor("invoice"),
+	}}}
+	if res, _ := r.callSkillRead(context.Background(), nil); !resultError(res) {
+		t.Error("missing name should error")
+	}
+	if res, _ := r.callSkillRead(context.Background(), map[string]any{"name": "nope"}); !resultError(res) {
+		t.Error("not found should error")
+	}
+	empty := &Registry{}
+	if res, _ := empty.callSkillRead(context.Background(), map[string]any{"name": "x"}); !resultError(res) {
+		t.Error("nil store should error")
+	}
+}
+
+func TestCallSkillFileList(t *testing.T) {
+	f := &fakeSkillStore{byName: map[string]*skills.Skill{
+		"invoice": skillFor("invoice"),
+		"empty":   skillFor("empty"),
+	}}
+	f.files = map[string]skills.Files{
+		"invoice": {
+			fileRow("references/x.md", "ref", skills.FileKindText),
+			fileRow("scripts/a.py", "print(1)", skills.FileKindText),
+		},
+	}
+	r := &Registry{skills: f}
+	res, err := r.callSkillFileList(context.Background(), map[string]any{"name": "invoice"})
+	if err != nil {
+		t.Fatalf("callSkillFileList: %v", err)
+	}
+	if text := resultText(res); text != "references/x.md (text/plain, 3 bytes)\nscripts/a.py (text/plain, 8 bytes)" {
+		t.Errorf("skill_file_list should return sorted manifest: %q", text)
+	}
+	if res, _ := r.callSkillFileList(context.Background(), map[string]any{"name": "empty"}); resultText(res) != "(no resource files)" {
+		t.Errorf("empty skill should report no files: %q", resultText(res))
+	}
+	if res, _ := r.callSkillFileList(context.Background(), map[string]any{"name": "nope"}); !resultError(res) {
+		t.Error("invisible skill should error")
+	}
+}
+
+func TestCallSkillFileRead(t *testing.T) {
+	f := &fakeSkillStore{byName: map[string]*skills.Skill{
+		"invoice": skillFor("invoice"),
+	}}
+	f.files = map[string]skills.Files{
+		"invoice": {
+			fileRow("scripts/a.py", "print(1)", skills.FileKindText),
+			fileRow("assets/logo.png", "PNG", skills.FileKindBinary),
+		},
+	}
+	r := &Registry{skills: f}
+	res, err := r.callSkillFileRead(context.Background(), map[string]any{"name": "invoice", "file": "scripts/a.py"})
+	if err != nil {
+		t.Fatalf("callSkillFileRead: %v", err)
+	}
+	if !strings.Contains(resultText(res), "print(1)") {
+		t.Errorf("skill_file_read result missing content: %q", resultText(res))
+	}
+	if res, _ := r.callSkillFileRead(context.Background(), map[string]any{"name": "invoice", "file": "assets/logo.png"}); resultError(res) {
+		t.Errorf("binary resource should not error: %q", resultText(res))
+	} else if text := resultText(res); !strings.Contains(text, "content not inlined") {
+		t.Errorf("binary resource should not inline content: %q", text)
+	}
+	if res, _ := r.callSkillFileRead(context.Background(), map[string]any{"name": "invoice", "file": "nope.py"}); !resultError(res) {
+		t.Error("unknown resource should error")
+	}
+	if res, _ := r.callSkillFileRead(context.Background(), map[string]any{"name": "invoice"}); !resultError(res) {
+		t.Error("missing file should error")
+	}
+}
+
+func TestCallSkillFileReadInvisibleSkill(t *testing.T) {
+	r := &Registry{skills: &fakeSkillStore{byName: map[string]*skills.Skill{
+		"invoice": skillFor("invoice"),
+	}}}
+	if res, _ := r.callSkillFileRead(context.Background(), map[string]any{"name": "nope", "file": "a.py"}); !resultError(res) {
+		t.Error("invisible skill should error")
+	}
+}
+
+func resultText(res map[string]any) string {
+	if content, ok := res["content"].([]map[string]any); ok && len(content) > 0 {
+		if text, ok := content[0]["text"].(string); ok {
+			return text
+		}
+	}
+	return ""
+}
+
+func resultError(res map[string]any) bool {
+	isErr, _ := res["isError"].(bool)
+	return isErr
+}

--- a/pkg/services/tools/zero_tools_test.go
+++ b/pkg/services/tools/zero_tools_test.go
@@ -153,7 +153,8 @@ func newTestRegistry() *Registry {
 func TestNewRegistry(t *testing.T) {
 	r := newTestRegistry()
 	if r == nil {
-		t.Fatal("NewRegistry returned nil")
+		t.Error("NewRegistry returned nil")
+		return
 	}
 	if len(r.tools) == 0 {
 		t.Error("should have at least fetch tool")

--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -42,7 +42,7 @@ type Config struct {
 
 	// OAuthInternalURL is the base URL for aurora internal API calls
 	OAuthInternalURL string `envconfig:"OAUTH_INTERNAL_URL" desc:"aurora internal API base URL, e.g. http://aurora:3560/api/intra"`
-	ServiceAuthKey    string `envconfig:"SERVICE_AUTH_KEY" desc:"pre-shared key for aurora internal service calls"`
+	ServiceAuthKey   string `envconfig:"SERVICE_AUTH_KEY" desc:"pre-shared key for aurora internal service calls"`
 
 	SitePathMe   string `envconfig:"Site_Path_Me" desc:"OAuth SP Path of /api/me in whole site"`
 	SiteTokenKey string `envconfig:"Site_Token_Key" default:"token" desc:"token key in whole site"`
@@ -69,6 +69,11 @@ type Config struct {
 
 	// LLM调用循环次数限制，防止无限循环
 	MaxLoopIterations int `envconfig:"MAX_LOOP_ITERATIONS" default:"12"`
+
+	// Skill 注入：清单数量小于该阈值时直接注入全文
+	SkillDirectThreshold int `envconfig:"SKILL_DIRECT_THRESHOLD" default:"3" desc:"skill 清单小于该数量时直接注入全文"`
+	// Skill 注入：频道默认加载的最近技能数量
+	SkillDefaultCount int `envconfig:"SKILL_DEFAULT_COUNT" default:"5" desc:"频道默认加载的最近技能数量"`
 
 	// Memory tier decay configuration
 	MemoryLongTermThreshold  float64 `envconfig:"MEMORY_LONG_TERM_THRESHOLD" default:"0.8"`

--- a/pkg/web/api/commands.go
+++ b/pkg/web/api/commands.go
@@ -3,8 +3,10 @@ package api
 import (
 	"context"
 	"strings"
+	"unicode"
 
 	"github.com/liut/morign/pkg/models/channel"
+	"github.com/liut/morign/pkg/models/skills"
 	"github.com/liut/morign/pkg/services/stores"
 )
 
@@ -22,18 +24,33 @@ var commandRegistry = []Command{
 		Desc:    "重置会话，创建新的 csid",
 		Action:  handleResetCommand,
 	},
+	{
+		Name:    "skill",
+		Aliases: []string{"/skill"},
+		Desc:    "激活技能全文注入",
+		Action:  handleSkillCommand,
+	},
 }
 
 func DetectCommand(content string) Command {
 	trimmed := strings.TrimSpace(content)
 	for _, cmd := range commandRegistry {
 		for _, alias := range cmd.Aliases {
-			if strings.HasPrefix(trimmed, alias) {
+			if isCommandMatch(trimmed, alias) {
 				return cmd
 			}
 		}
 	}
 	return Command{}
+}
+
+// isCommandMatch 指令需为完整单词：别名后紧跟空白（空格/回车/tab 等）或消息结束。
+func isCommandMatch(content, alias string) bool {
+	if !strings.HasPrefix(content, alias) {
+		return false
+	}
+	rest := content[len(alias):]
+	return rest == "" || unicode.IsSpace(rune(rest[0]))
 }
 
 func handleResetCommand(ctx context.Context, msg *channel.Message) (bool, error) {
@@ -42,4 +59,25 @@ func handleResetCommand(ctx context.Context, msg *channel.Message) (bool, error)
 	}
 	logger().Infow("command: session reset", "sessionKey", msg.SessionKey)
 	return true, nil
+}
+
+// handleSkillCommand 解析 /skill <name> 后的技能名并剥离指令文本，继续正常对话流程。
+func handleSkillCommand(ctx context.Context, msg *channel.Message) (bool, error) {
+	content := strings.TrimSpace(msg.Content)
+	rest, ok := strings.CutPrefix(content, "/skill")
+	if !ok {
+		return false, nil
+	}
+	if rest != "" && !unicode.IsSpace(rune(rest[0])) {
+		return false, nil
+	}
+	rest = strings.TrimSpace(rest)
+	name, tail, _ := strings.Cut(rest, " ")
+	name = strings.TrimSpace(name)
+	if !skills.ValidName(name) {
+		return false, nil // 非法指令，按普通消息继续
+	}
+	msg.SkillName = name
+	msg.Content = strings.TrimSpace(tail)
+	return false, nil
 }

--- a/pkg/web/api/commands_test.go
+++ b/pkg/web/api/commands_test.go
@@ -1,0 +1,104 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/liut/morign/pkg/models/channel"
+)
+
+func TestDetectSkillCommand(t *testing.T) {
+	msg := &channel.Message{Content: "/skill invoice 帮我开发票"}
+	if cmd := DetectCommand(msg.Content); cmd.Name != "skill" {
+		t.Fatalf("DetectCommand = %q, want skill", cmd.Name)
+	}
+}
+
+func TestHandleSkillCommand(t *testing.T) {
+	msg := &channel.Message{Content: "/skill invoice 帮我开发票"}
+	handled, err := handleSkillCommand(context.Background(), msg)
+	if err != nil {
+		t.Fatalf("handleSkillCommand: %v", err)
+	}
+	if handled {
+		t.Error("skill command should continue, not stop")
+	}
+	if msg.SkillName != "invoice" {
+		t.Errorf("SkillName = %q, want invoice", msg.SkillName)
+	}
+	if msg.Content != "帮我开发票" {
+		t.Errorf("Content = %q, want 帮我开发票", msg.Content)
+	}
+}
+
+func TestHandleSkillCommandInvalid(t *testing.T) {
+	msg := &channel.Message{Content: "/skill PDF"}
+	if _, err := handleSkillCommand(context.Background(), msg); err != nil {
+		t.Fatalf("handleSkillCommand: %v", err)
+	}
+	if msg.SkillName != "" {
+		t.Errorf("invalid name should not set SkillName, got %q", msg.SkillName)
+	}
+	if msg.Content != "/skill PDF" {
+		t.Errorf("invalid command should keep content, got %q", msg.Content)
+	}
+}
+
+func TestHandleSkillCommandBare(t *testing.T) {
+	msg := &channel.Message{Content: "/skill"}
+	if _, err := handleSkillCommand(context.Background(), msg); err != nil {
+		t.Fatalf("handleSkillCommand: %v", err)
+	}
+	if msg.SkillName != "" || msg.Content != "/skill" {
+		t.Errorf("bare command should be untouched, got %q / %q", msg.SkillName, msg.Content)
+	}
+}
+
+func TestHandleSkillCommandPrefixCollision(t *testing.T) {
+	for _, content := range []string{"/skillset 怎么办", "/skillful 做法", "/skillinvoice"} {
+		msg := &channel.Message{Content: content}
+		if _, err := handleSkillCommand(context.Background(), msg); err != nil {
+			t.Fatalf("handleSkillCommand(%q): %v", content, err)
+		}
+		if msg.SkillName != "" || msg.Content != content {
+			t.Errorf("prefix collision should be untouched, got %q / %q", msg.SkillName, msg.Content)
+		}
+	}
+}
+
+func TestDetectCommandCompleteMatch(t *testing.T) {
+	cases := []struct {
+		content string
+		want    string
+	}{
+		{"/skill invoice", "skill"},
+		{"/skill", "skill"},
+		{"  /skill invoice  ", "skill"},
+		{"/skill\tinvoice", "skill"},
+		{"/reset", "reset"},
+		{"\r\n/reset\r\n", "reset"},
+		{"/skillset 怎么办", ""},
+		{"/skillful 做法", ""},
+		{"/resetc", ""},
+		{"/clearx", ""},
+		{"普通消息 /skill invoice", ""},
+	}
+	for _, c := range cases {
+		if got := DetectCommand(c.content).Name; got != c.want {
+			t.Errorf("DetectCommand(%q) = %q, want %q", c.content, got, c.want)
+		}
+	}
+}
+
+func TestHandleSkillCommandWhitespace(t *testing.T) {
+	msg := &channel.Message{Content: "  /skill invoice  帮我开发票  \r\n"}
+	if _, err := handleSkillCommand(context.Background(), msg); err != nil {
+		t.Fatalf("handleSkillCommand: %v", err)
+	}
+	if msg.SkillName != "invoice" {
+		t.Errorf("SkillName = %q, want invoice", msg.SkillName)
+	}
+	if msg.Content != "帮我开发票" {
+		t.Errorf("Content = %q, want 帮我开发票", msg.Content)
+	}
+}

--- a/pkg/web/api/convo_basic.go
+++ b/pkg/web/api/convo_basic.go
@@ -14,6 +14,8 @@ type ChatRequest struct {
 	Stream          bool   `json:"stream"`
 
 	MCPs []string `json:"mcps,omitempty"`
+	// 技能清单范围：仅圈定注入 system prompt 的技能元数据
+	Skills []string `json:"skills,omitempty"`
 
 	// deprecated: for github.com/Chanzhaoyu/chatgpt-web only
 	Options struct {

--- a/pkg/web/api/handle_convo.go
+++ b/pkg/web/api/handle_convo.go
@@ -55,11 +55,12 @@ type chatRequest struct {
 	isSSE    bool
 	cs       stores.Conversation
 	prompt   string
+	skills   []string
 }
 
 // prepareSystemMessage 准备系统消息，包括基础 prompt、记忆、工具或知识库
 func prepareSystemMessage(ctx context.Context, sto stores.Storage,
-	toolreg *tools.Registry, prompt string, cs stores.Conversation) (
+	toolreg *tools.Registry, prompt string, skills []string, cs stores.Conversation) (
 	llm.Message, []llm.ToolDefinition) {
 	var sb strings.Builder
 
@@ -130,6 +131,8 @@ func prepareSystemMessage(ctx context.Context, sto stores.Storage,
 		sb.WriteString(sto.Preset().ChannelPrompt)
 	}
 
+	appendSkillPrompt(ctx, &sb, sto.Skill(), skills)
+
 	msg := llm.Message{
 		Role:    llm.RoleSystem,
 		Content: sb.String(),
@@ -138,10 +141,22 @@ func prepareSystemMessage(ctx context.Context, sto stores.Storage,
 	return msg, tools
 }
 
+// appendSkillPrompt 将技能注入块追加到 system prompt 构建器，失败时降级为空。
+func appendSkillPrompt(ctx context.Context, sb *strings.Builder, sk agent.SkillStore, requested []string) {
+	block, err := agent.BuildSkillPrompt(ctx, sk, requested)
+	if err != nil {
+		logger().Warnw("skill prompt fail", "err", err)
+		return
+	}
+	if block != "" {
+		sb.WriteString(block)
+	}
+}
+
 func (a *api) prepareChatRequest(ctx context.Context, param *ChatRequest) *chatRequest {
 	cs := stores.NewConversation(ctx, param.GetConversionID())
 
-	sysMsg, tools := prepareSystemMessage(ctx, a.sto, a.toolreg, param.Prompt, cs)
+	sysMsg, tools := prepareSystemMessage(ctx, a.sto, a.toolreg, param.Prompt, param.Skills, cs)
 	messages := []llm.Message{sysMsg}
 
 	data, err := cs.ListHistory(ctx)
@@ -185,6 +200,7 @@ func (a *api) prepareChatRequest(ctx context.Context, param *ChatRequest) *chatR
 		tools:    tools,
 		cs:       cs,
 		prompt:   param.Prompt,
+		skills:   param.Skills,
 	}
 }
 

--- a/pkg/web/api/handle_convo_test.go
+++ b/pkg/web/api/handle_convo_test.go
@@ -1,12 +1,48 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
+	"github.com/liut/morign/pkg/models/skills"
 	"github.com/liut/morign/pkg/services/llm"
+	"github.com/liut/morign/pkg/settings"
 )
 
+type fakeSkillStore struct {
+	byName map[string]*skills.Skill
+	recent []skills.Skill
+	err    error
+}
+
+func (f *fakeSkillStore) TopRecent(ctx context.Context, limit int) (skills.Skills, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if limit <= 0 || limit > len(f.recent) {
+		limit = len(f.recent)
+	}
+	return f.recent[:limit], nil
+}
+
+func (f *fakeSkillStore) LoadForName(ctx context.Context, name string) (*skills.Skill, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	obj, ok := f.byName[name]
+	if !ok {
+		return nil, errSkillNotFound
+	}
+	return obj, nil
+}
+
+var errSkillNotFound = errFakeNotFound{}
+
+type errFakeNotFound struct{}
+
+func (errFakeNotFound) Error() string { return "skill not found" }
 
 func TestConvertToolCallsForJSON(t *testing.T) {
 	tests := []struct {
@@ -128,6 +164,57 @@ func TestConvertToolCallsForJSON_Serialize(t *testing.T) {
 	}
 }
 
+func TestAppendSkillPromptDirect(t *testing.T) {
+	settings.Current.SkillDirectThreshold = 3
+	f := &fakeSkillStore{byName: map[string]*skills.Skill{
+		"a": skillFor("a", "A", "content-a"),
+		"b": skillFor("b", "B", "content-b"),
+	}}
+	var sb strings.Builder
+	appendSkillPrompt(context.Background(), &sb, f, []string{"a", "b"})
+	if !strings.Contains(sb.String(), "content-a") || !strings.Contains(sb.String(), "content-b") {
+		t.Errorf("expected full contents, got %q", sb.String())
+	}
+}
+
+func TestAppendSkillPromptMetadata(t *testing.T) {
+	settings.Current.SkillDirectThreshold = 3
+	f := &fakeSkillStore{byName: map[string]*skills.Skill{}}
+	for _, name := range []string{"a", "b", "c", "d", "e"} {
+		f.byName[name] = skillFor(name, "desc-"+name, "content-"+name)
+	}
+	var sb strings.Builder
+	appendSkillPrompt(context.Background(), &sb, f, []string{"a", "b", "c", "d", "e"})
+	out := sb.String()
+	if !strings.Contains(out, "desc-a") || strings.Contains(out, "content-a") {
+		t.Errorf("expected metadata only, got %q", out)
+	}
+	if !strings.Contains(out, "skill_read") {
+		t.Errorf("metadata should hint skill_read, got %q", out)
+	}
+}
+
+func TestAppendSkillPromptDegrade(t *testing.T) {
+	f := &fakeSkillStore{err: errFakeNotFound{}}
+	var sb strings.Builder
+	appendSkillPrompt(context.Background(), &sb, f, []string{"a"})
+	if sb.String() != "" {
+		t.Errorf("store error should degrade to empty, got %q", sb.String())
+	}
+}
+
+func TestAppendSkillPromptEmpty(t *testing.T) {
+	var sb strings.Builder
+	appendSkillPrompt(context.Background(), &sb, &fakeSkillStore{}, nil)
+	if sb.String() != "" {
+		t.Errorf("no skills should inject nothing, got %q", sb.String())
+	}
+}
+
+func skillFor(name, desc, content string) *skills.Skill {
+	return &skills.Skill{SkillBasic: skills.SkillBasic{Name: name, Description: desc, Content: content}}
+}
+
 func TestConvertToolCallsForJSON_IncompleteJSON(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -194,4 +281,3 @@ func TestConvertToolCallsForJSON_IncompleteJSON(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/web/api/handle_platform.go
+++ b/pkg/web/api/handle_platform.go
@@ -348,7 +348,11 @@ func translateLLMErrorToUser(err error) string {
 
 // buildChatMessagesAndTools builds the message list and returns tools for the chat.
 func (chh *channelHandler) buildChatMessagesAndTools(ctx context.Context, msg *channel.Message, cs stores.Conversation) ([]llm.Message, []llm.ToolDefinition) {
-	sysMsg, tools := prepareSystemMessage(ctx, chh.sto, chh.toolreg, msg.Content, cs)
+	var requested []string
+	if msg.SkillName != "" {
+		requested = []string{msg.SkillName}
+	}
+	sysMsg, tools := prepareSystemMessage(ctx, chh.sto, chh.toolreg, msg.Content, requested, cs)
 
 	content := msg.Content
 	if len(msg.Images) > 0 {

--- a/pkg/web/api/handle_skills_gen.go
+++ b/pkg/web/api/handle_skills_gen.go
@@ -1,0 +1,168 @@
+// This file is generated - Do Not Edit.
+
+package api
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/liut/morign/pkg/models/skills"
+	"github.com/liut/morign/pkg/services/stores"
+	binder "github.com/marcsv/go-binder/binder"
+)
+
+func init() {
+	regHI(true, "GET", "/admin/skills", "admin-skills-get", func(a *api) http.HandlerFunc {
+		return a.getSkills
+	})
+	regHI(true, "GET", "/admin/skills/:id", "admin-skills-id-get", func(a *api) http.HandlerFunc {
+		return a.getSkill
+	})
+	regHI(true, "POST", "/admin/skills", "admin-skills-post", func(a *api) http.HandlerFunc {
+		return a.postSkill
+	})
+	regHI(true, "PUT", "/admin/skills/:id", "admin-skills-id-put", func(a *api) http.HandlerFunc {
+		return a.putSkill
+	})
+	regHI(true, "DELETE", "/admin/skills/:id", "admin-skills-id-delete", func(a *api) http.HandlerFunc {
+		return a.deleteSkill
+	})
+}
+
+// @Tags 默认 文档生成
+// @ID admin-skills-get
+// @Summary 查询 技能 列表 🔑
+// @Accept json
+// @Produce json
+// @Param token    header   string  true "登录票据凭证"
+// @Param   query  query   stores.SkillSpec  true   "Object"
+// @Success 200 {object} Done{result=ResultData{data=skills.Skills}}
+// @Failure 400 {object} Failure "请求或参数错误"
+// @Failure 401 {object} Failure "未登录"
+// @Failure 404 {object} Failure "目标未找到"
+// @Failure 503 {object} Failure "服务端错误"
+// @Router /api/admin/skills [get]
+func (a *api) getSkills(w http.ResponseWriter, r *http.Request) {
+	var spec stores.SkillSpec
+	if err := queryBinder.Bind(&spec, r.URL); err != nil {
+		fail(w, r, 400, err)
+		return
+	}
+
+	ctx := r.Context()
+	data, total, err := a.sto.Skill().ListSkill(ctx, &spec)
+	if err != nil {
+		fail(w, r, 503, err)
+		return
+	}
+
+	success(w, r, dtResult(data, total))
+}
+
+// @Tags 默认 文档生成
+// @ID admin-skills-id-get
+// @Summary 获取 技能 详情 🔑
+// @Accept json
+// @Produce json
+// @Param token    header   string  true "登录票据凭证"
+// @Param   id    path   string  true   "编号"
+// @Success 200 {object} Done{result=skills.Skill}
+// @Failure 400 {object} Failure "请求或参数错误"
+// @Failure 401 {object} Failure "未登录"
+// @Failure 404 {object} Failure "目标未找到"
+// @Failure 503 {object} Failure "服务端错误"
+// @Router /api/admin/skills/{id} [get]
+func (a *api) getSkill(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	obj, err := a.sto.Skill().GetSkill(r.Context(), id)
+	if err != nil {
+		fail(w, r, 503, err)
+		return
+	}
+
+	success(w, r, obj)
+}
+
+// @Tags 默认 文档生成
+// @ID admin-skills-post
+// @Summary 录入 技能 🔑
+// @Accept json,mpfd
+// @Produce json
+// @Param token    header   string  true "登录票据凭证"
+// @Param   query  body   skills.SkillBasic  true   "Object"
+// @Success 200 {object} Done{result=ResultID}
+// @Failure 400 {object} Failure "请求或参数错误"
+// @Failure 401 {object} Failure "未登录"
+// @Failure 403 {object} Failure "无权限"
+// @Failure 503 {object} Failure "服务端错误"
+// @Router /api/admin/skills [post]
+func (a *api) postSkill(w http.ResponseWriter, r *http.Request) {
+	var in skills.SkillBasic
+	if err := binder.BindBody(r, &in); err != nil {
+		fail(w, r, 400, err)
+		return
+	}
+
+	obj, err := a.sto.Skill().CreateSkill(r.Context(), in)
+	if err != nil {
+		fail(w, r, 503, err)
+		return
+	}
+
+	success(w, r, idResult(obj.ID))
+}
+
+// @Tags 默认 文档生成
+// @ID admin-skills-id-put
+// @Summary 更新 技能 🔑
+// @Accept json,mpfd
+// @Produce json
+// @Param token    header   string  true "登录票据凭证"
+// @Param   id    path   string  true   "编号"
+// @Param   query  body   skills.SkillSet  true   "Object"
+// @Success 200 {object} Done{result=string}
+// @Failure 400 {object} Failure "请求或参数错误"
+// @Failure 401 {object} Failure "未登录"
+// @Failure 403 {object} Failure "无权限"
+// @Failure 503 {object} Failure "服务端错误"
+// @Router /api/admin/skills/{id} [put]
+func (a *api) putSkill(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var in skills.SkillSet
+	if err := binder.BindBody(r, &in); err != nil {
+		fail(w, r, 400, err)
+		return
+	}
+
+	err := a.sto.Skill().UpdateSkill(r.Context(), id, in)
+	if err != nil {
+		fail(w, r, 503, err)
+		return
+	}
+
+	success(w, r, "ok")
+}
+
+// @Tags 默认 文档生成
+// @ID admin-skills-id-delete
+// @Summary 删除 技能 🔑
+// @Accept json
+// @Produce json
+// @Param token    header   string  true "登录票据凭证"
+// @Param   id    path   string  true   "编号"
+// @Success 200 {object} Done
+// @Failure 400 {object} Failure "请求或参数错误"
+// @Failure 401 {object} Failure "未登录"
+// @Failure 403 {object} Failure "无权限"
+// @Failure 503 {object} Failure "服务端错误"
+// @Router /api/admin/skills/{id} [delete]
+func (a *api) deleteSkill(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	err := a.sto.Skill().DeleteSkill(r.Context(), id)
+	if err != nil {
+		fail(w, r, 503, err)
+		return
+	}
+
+	success(w, r, "ok")
+}

--- a/pkg/web/api/handle_skills_x.go
+++ b/pkg/web/api/handle_skills_x.go
@@ -1,0 +1,247 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/cupogo/andvari/models/oid"
+	"github.com/go-chi/chi/v5"
+	binder "github.com/marcsv/go-binder/binder"
+
+	"github.com/liut/morign/pkg/models/skills"
+	"github.com/liut/morign/pkg/services/stores"
+)
+
+var errSkillNeedLogin = errors.New("need login")
+
+type skillCreateIn struct {
+	skills.SkillBasic
+	Files map[string]string `json:"files,omitempty"`
+}
+
+type skillUpdateIn struct {
+	skills.SkillSet
+	Files map[string]string `json:"files,omitempty"`
+}
+
+type skillDetail struct {
+	skills.Skill
+	Files skills.Files `json:"files"`
+}
+
+func init() {
+	regHI(true, "GET", "/skills", "", func(a *api) http.HandlerFunc {
+		return a.listSkills
+	})
+	regHI(true, "GET", "/skills/:name", "", func(a *api) http.HandlerFunc {
+		return a.getSkillByName
+	})
+	regHI(true, "POST", "/skills", "", func(a *api) http.HandlerFunc {
+		return a.createSkill
+	})
+	regHI(true, "PUT", "/skills/:name", "", func(a *api) http.HandlerFunc {
+		return a.updateSkill
+	})
+	regHI(true, "DELETE", "/skills/:name", "", func(a *api) http.HandlerFunc {
+		return a.deleteSkillByName
+	})
+}
+
+// listSkills 返回当前用户可见范围的技能元数据（不含全文）。
+// @Tags 技能
+// @Summary 查询 可见技能列表（元数据）
+// @Accept json
+// @Produce json
+// @Param token header string true "登录票据凭证"
+// @Param query query stores.SkillSpec true "Object"
+// @Success 200 {object} Done{result=ResultData{data=skills.Skills}}
+// @Failure 400 {object} Failure "请求或参数错误"
+// @Failure 401 {object} Failure "未登录"
+// @Failure 503 {object} Failure "服务端错误"
+// @Router /api/skills [get]
+func (a *api) listSkills(w http.ResponseWriter, r *http.Request) {
+	var spec stores.SkillSpec
+	if err := queryBinder.Bind(&spec, r.URL); err != nil {
+		fail(w, r, 400, err)
+		return
+	}
+	data, total, err := a.sto.Skill().ListVisibleMetadata(r.Context(), &spec)
+	if err != nil {
+		fail(w, r, 503, err)
+		return
+	}
+	success(w, r, dtResult(data, total))
+}
+
+// getSkillByName 返回可见技能详情（含全文与资源文件清单，不含文件内容）。
+// @Tags 技能
+// @Summary 获取 技能详情
+// @Accept json
+// @Produce json
+// @Param token header string true "登录票据凭证"
+// @Param name path string true "技能名"
+// @Success 200 {object} Done{result=skillDetail}
+// @Failure 400 {object} Failure "请求或参数错误"
+// @Failure 401 {object} Failure "未登录"
+// @Failure 404 {object} Failure "目标未找到"
+// @Failure 503 {object} Failure "服务端错误"
+// @Router /api/skills/{name} [get]
+func (a *api) getSkillByName(w http.ResponseWriter, r *http.Request) {
+	obj, err := a.sto.Skill().LoadForName(r.Context(), chi.URLParam(r, "name"))
+	if err != nil {
+		fail(w, r, 404, err)
+		return
+	}
+	files, err := a.sto.Skill().ListFileNames(r.Context(), obj.Name)
+	if err != nil {
+		fail(w, r, 503, err)
+		return
+	}
+	success(w, r, skillDetail{Skill: *obj, Files: files})
+}
+
+// createSkill 创建当前用户自己的技能：owner 强制、Channel 默认私有（不投放）、
+// 校验 name 格式与 SKILL.md frontmatter、name 全局唯一。
+// @Tags 技能
+// @Summary 创建 自己的技能
+// @Accept json,mpfd
+// @Produce json
+// @Param token header string true "登录票据凭证"
+// @Param query body skillCreateIn true "Object"
+// @Success 200 {object} Done{result=ResultID}
+// @Failure 400 {object} Failure "请求或参数错误"
+// @Failure 401 {object} Failure "未登录"
+// @Failure 503 {object} Failure "服务端错误"
+// @Router /api/skills [post]
+func (a *api) createSkill(w http.ResponseWriter, r *http.Request) {
+	user, ok := stores.UserFromContext(r.Context())
+	if !ok {
+		fail(w, r, 401, errSkillNeedLogin)
+		return
+	}
+	var in skillCreateIn
+	if err := binder.BindBody(r, &in); err != nil {
+		fail(w, r, 400, err)
+		return
+	}
+	if !skills.ValidName(in.Name) {
+		fail(w, r, 400, skills.ErrInvalidName)
+		return
+	}
+	if !skills.ValidDescription(in.Description) {
+		fail(w, r, 400, skills.ErrDescriptionLong)
+		return
+	}
+	if err := skills.ValidateFrontmatter(in.Content, in.Name, in.Description); err != nil {
+		fail(w, r, 400, err)
+		return
+	}
+	in.Owner = oid.Cast(user.OID)
+	obj, err := a.sto.Skill().CreateSkillWithFiles(r.Context(), in.SkillBasic, in.Files)
+	if err != nil {
+		if errors.Is(err, stores.ErrDuplicate) {
+			fail(w, r, 400, errors.New("skill name already exists"))
+			return
+		}
+		fail(w, r, 503, err)
+		return
+	}
+	success(w, r, idResult(obj.ID))
+}
+
+// updateSkill 仅允许更新自己的技能；name 不可变更。
+// @Tags 技能
+// @Summary 更新 自己的技能
+// @Accept json,mpfd
+// @Produce json
+// @Param token header string true "登录票据凭证"
+// @Param name path string true "技能名"
+// @Param query body skillUpdateIn true "Object"
+// @Success 200 {object} Done{result=ResultID}
+// @Failure 400 {object} Failure "请求或参数错误"
+// @Failure 401 {object} Failure "未登录"
+// @Failure 403 {object} Failure "无权限"
+// @Failure 404 {object} Failure "目标未找到"
+// @Failure 503 {object} Failure "服务端错误"
+// @Router /api/skills/{name} [put]
+func (a *api) updateSkill(w http.ResponseWriter, r *http.Request) {
+	user, ok := stores.UserFromContext(r.Context())
+	if !ok {
+		fail(w, r, 401, errSkillNeedLogin)
+		return
+	}
+	name := chi.URLParam(r, "name")
+	var in skillUpdateIn
+	if err := binder.BindBody(r, &in); err != nil {
+		fail(w, r, 400, err)
+		return
+	}
+	obj, err := a.sto.Skill().GetSkill(r.Context(), name)
+	if err != nil {
+		fail(w, r, 404, err)
+		return
+	}
+	if obj.Owner != oid.Cast(user.OID) {
+		fail(w, r, 403, errors.New("permission denied"))
+		return
+	}
+	if in.Name != nil && (*in.Name != name || !skills.ValidName(*in.Name)) {
+		fail(w, r, 400, skills.ErrInvalidName)
+		return
+	}
+	if in.Description != nil && !skills.ValidDescription(*in.Description) {
+		fail(w, r, 400, skills.ErrDescriptionLong)
+		return
+	}
+	if in.Content != nil {
+		desc := obj.Description
+		if in.Description != nil {
+			desc = *in.Description
+		}
+		if err := skills.ValidateFrontmatter(*in.Content, name, desc); err != nil {
+			fail(w, r, 400, err)
+			return
+		}
+	}
+	if err := a.sto.Skill().UpdateSkillWithFiles(r.Context(), obj.ID.String(), in.SkillSet, in.Files); err != nil {
+		fail(w, r, 503, err)
+		return
+	}
+	success(w, r, idResult(obj.ID))
+}
+
+// deleteSkillByName 仅允许删除自己的技能。
+// @Tags 技能
+// @Summary 删除 自己的技能
+// @Accept json
+// @Produce json
+// @Param token header string true "登录票据凭证"
+// @Param name path string true "技能名"
+// @Success 200 {object} Done{result=string}
+// @Failure 400 {object} Failure "请求或参数错误"
+// @Failure 401 {object} Failure "未登录"
+// @Failure 403 {object} Failure "无权限"
+// @Failure 404 {object} Failure "目标未找到"
+// @Failure 503 {object} Failure "服务端错误"
+// @Router /api/skills/{name} [delete]
+func (a *api) deleteSkillByName(w http.ResponseWriter, r *http.Request) {
+	user, ok := stores.UserFromContext(r.Context())
+	if !ok {
+		fail(w, r, 401, errSkillNeedLogin)
+		return
+	}
+	obj, err := a.sto.Skill().GetSkill(r.Context(), chi.URLParam(r, "name"))
+	if err != nil {
+		fail(w, r, 404, err)
+		return
+	}
+	if obj.Owner != oid.Cast(user.OID) {
+		fail(w, r, 403, errors.New("permission denied"))
+		return
+	}
+	if err := a.sto.Skill().DeleteSkill(r.Context(), obj.ID.String()); err != nil {
+		fail(w, r, 503, err)
+		return
+	}
+	success(w, r, "ok")
+}

--- a/pkg/web/api/skill_user_test.go
+++ b/pkg/web/api/skill_user_test.go
@@ -1,0 +1,336 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cupogo/andvari/models/oid"
+	"github.com/go-chi/chi/v5"
+	auth "github.com/liut/simpauth"
+
+	"github.com/liut/morign/pkg/models/aigc"
+	"github.com/liut/morign/pkg/models/skills"
+	"github.com/liut/morign/pkg/services/stores"
+)
+
+type memSkillStore struct {
+	byName map[string]*skills.Skill
+	files  map[string]skills.Files
+	seq    int
+}
+
+func (f *memSkillStore) ListVisibleMetadata(ctx context.Context, spec *stores.SkillSpec) (skills.Skills, int, error) {
+	var data skills.Skills
+	for _, obj := range f.byName {
+		data = append(data, *obj)
+	}
+	return data, len(data), nil
+}
+
+func (f *memSkillStore) TopRecent(ctx context.Context, limit int) (skills.Skills, error) {
+	return nil, nil
+}
+
+func (f *memSkillStore) LoadForName(ctx context.Context, name string) (*skills.Skill, error) {
+	obj, ok := f.byName[name]
+	if !ok {
+		return nil, stores.ErrNotFound
+	}
+	return obj, nil
+}
+
+func (f *memSkillStore) ListSkill(ctx context.Context, spec *stores.SkillSpec) (skills.Skills, int, error) {
+	return f.ListVisibleMetadata(ctx, spec)
+}
+
+func (f *memSkillStore) GetSkill(ctx context.Context, id string) (*skills.Skill, error) {
+	if obj, ok := f.byName[id]; ok {
+		return obj, nil
+	}
+	for _, obj := range f.byName {
+		if obj.ID.String() == id {
+			return obj, nil
+		}
+	}
+	return nil, stores.ErrNotFound
+}
+
+func (f *memSkillStore) CreateSkill(ctx context.Context, in skills.SkillBasic) (*skills.Skill, error) {
+	if _, ok := f.byName[in.Name]; ok {
+		return nil, stores.ErrDuplicate
+	}
+	f.seq++
+	obj := skills.NewSkillWithBasic(in)
+	obj.SetID(oid.NewID(oid.OtFile))
+	f.byName[in.Name] = obj
+	return obj, nil
+}
+
+func (f *memSkillStore) CreateSkillWithFiles(ctx context.Context, in skills.SkillBasic, files map[string]string) (*skills.Skill, error) {
+	obj, err := f.CreateSkill(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	f.setFiles(obj.Name, files)
+	return obj, nil
+}
+
+func (f *memSkillStore) UpdateSkill(ctx context.Context, id string, in skills.SkillSet) error {
+	for _, obj := range f.byName {
+		if obj.ID.String() == id {
+			if in.Description != nil {
+				obj.Description = *in.Description
+			}
+			if in.Content != nil {
+				obj.Content = *in.Content
+			}
+			return nil
+		}
+	}
+	return stores.ErrNotFound
+}
+
+func (f *memSkillStore) DeleteSkill(ctx context.Context, id string) error {
+	for name, obj := range f.byName {
+		if obj.ID.String() == id {
+			delete(f.byName, name)
+			return nil
+		}
+	}
+	return stores.ErrNotFound
+}
+
+func (f *memSkillStore) UpdateSkillWithFiles(ctx context.Context, id string, set skills.SkillSet, files map[string]string) error {
+	for _, obj := range f.byName {
+		if obj.ID.String() == id {
+			if set.Description != nil {
+				obj.Description = *set.Description
+			}
+			if set.Content != nil {
+				obj.Content = *set.Content
+			}
+			if files != nil {
+				f.setFiles(obj.Name, files)
+			}
+			return nil
+		}
+	}
+	return stores.ErrNotFound
+}
+
+func (f *memSkillStore) ListFileNames(ctx context.Context, name string) (skills.Files, error) {
+	if _, ok := f.byName[name]; !ok {
+		return nil, stores.ErrNotFound
+	}
+	return f.files[name], nil
+}
+
+func (f *memSkillStore) ListFile(ctx context.Context, spec *stores.FileSpec) (skills.Files, int, error) {
+	// 单测未走生成 ListFile 路径，文件访问均经 ListFileNames/ReadFile。
+	return nil, 0, nil
+}
+
+func (f *memSkillStore) ReadFile(ctx context.Context, name, path string) (*skills.File, error) {
+	for i := range f.files[name] {
+		if f.files[name][i].Path == path {
+			return &f.files[name][i], nil
+		}
+	}
+	return nil, stores.ErrFileNotFound
+}
+
+func (f *memSkillStore) setFiles(name string, files map[string]string) {
+	rows := make(skills.Files, 0, len(files))
+	for path, content := range files {
+		rows = append(rows, skills.File{FileBasic: skills.FileBasic{
+			Path:    path,
+			Content: []byte(content),
+			Mime:    "text/plain",
+			Kind:    skills.FileKindText,
+			Size:    int64(len(content)),
+		}})
+	}
+	f.files[name] = rows
+}
+
+type fakeStorage struct {
+	skill *memSkillStore
+}
+
+func (f *fakeStorage) Preset() aigc.Preset                { return aigc.Preset{} }
+func (f *fakeStorage) Corpus() stores.CorpuStore          { return nil }
+func (f *fakeStorage) KB() stores.CorpuStore              { return nil }
+func (f *fakeStorage) MCP() stores.MCPStore               { return nil }
+func (f *fakeStorage) Convo() stores.ConvoStore           { return nil }
+func (f *fakeStorage) State() stores.StateStore           { return nil }
+func (f *fakeStorage) Capability() stores.CapabilityStore { return nil }
+func (f *fakeStorage) Skill() stores.SkillStore           { return f.skill }
+
+func skillAPI() (*api, *memSkillStore) {
+	fk := &memSkillStore{byName: map[string]*skills.Skill{}, files: map[string]skills.Files{}}
+	return &api{sto: &fakeStorage{skill: fk}}, fk
+}
+
+func skillRouter(a *api) *chi.Mux {
+	r := chi.NewRouter()
+	r.Get("/api/skills", a.listSkills)
+	r.Get("/api/skills/{name}", a.getSkillByName)
+	r.Post("/api/skills", a.createSkill)
+	r.Put("/api/skills/{name}", a.updateSkill)
+	r.Delete("/api/skills/{name}", a.deleteSkillByName)
+	return r
+}
+
+func withUser(req *http.Request, oidStr string) *http.Request {
+	ctx := auth.ContextWithUser(req.Context(), &auth.User{OID: oidStr, UID: "u", Name: "u"})
+	return req.WithContext(ctx)
+}
+
+func doSkillReq(r *chi.Mux, method, path, body, user string) *httptest.ResponseRecorder {
+	var reader io.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	}
+	req := httptest.NewRequest(method, path, reader)
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req = withUser(req, user)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	return rr
+}
+
+func respCode(t *testing.T, rr *httptest.ResponseRecorder) int {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &m); err != nil {
+		t.Fatalf("decode: %v (body %s)", err, rr.Body.String())
+	}
+	code, _ := m["status"].(float64)
+	return int(code)
+}
+
+func TestSkillCreateAPI(t *testing.T) {
+	a, fk := skillAPI()
+	r := skillRouter(a)
+	body := `{"name":"invoice","description":"开发票","content":"---\nname: invoice\ndescription: 开发票\n---\n\n正文"}`
+	rr := doSkillReq(r, http.MethodPost, "/api/skills", body, "o1")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("create status = %d, body %s", rr.Code, rr.Body.String())
+	}
+	obj := fk.byName["invoice"]
+	if obj == nil || obj.Owner != oid.Cast("o1") {
+		t.Errorf("owner not forced: %+v", obj)
+	}
+}
+
+func TestSkillCreateAPIValidation(t *testing.T) {
+	a, fk := skillAPI()
+	r := skillRouter(a)
+	cases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{"bad name", `{"name":"PDF","description":"d","content":"---\nname: PDF\ndescription: d\n---\nbody"}`, 400},
+		{"missing frontmatter", `{"name":"invoice","description":"d","content":"plain"}`, 400},
+		{"frontmatter mismatch", `{"name":"invoice","description":"d","content":"---\nname: other\ndescription: d\n---\nbody"}`, 400},
+		{"long description", `{"name":"invoice","description":"` + strings.Repeat("a", 125) + `","content":"---\nname: invoice\ndescription: d\n---\nbody"}`, 400},
+	}
+	for _, c := range cases {
+		rr := doSkillReq(r, http.MethodPost, "/api/skills", c.body, "o1")
+		if got := respCode(t, rr); got != c.want {
+			t.Errorf("%s: code = %d, want %d (body %s)", c.name, got, c.want, rr.Body.String())
+		}
+	}
+	if len(fk.byName) != 0 {
+		t.Errorf("no skill should be stored, got %v", fk.byName)
+	}
+}
+
+func TestSkillCreateAPIDuplicate(t *testing.T) {
+	a, fk := skillAPI()
+	r := skillRouter(a)
+	content := "---\nname: invoice\ndescription: d\n---\nbody"
+	fk.byName["invoice"] = &skills.Skill{SkillBasic: skills.SkillBasic{
+		Name: "invoice", Description: "d", Content: content, Owner: oid.Cast("o1"),
+	}}
+	body := `{"name":"invoice","description":"d","content":"---\nname: invoice\ndescription: d\n---\nbody"}`
+	rr := doSkillReq(r, http.MethodPost, "/api/skills", body, "o1")
+	if got := respCode(t, rr); got != http.StatusBadRequest {
+		t.Errorf("duplicate code = %d, want 400", got)
+	}
+}
+
+func TestSkillUpdateDeleteAPI(t *testing.T) {
+	a, fk := skillAPI()
+	r := skillRouter(a)
+	content := "---\nname: invoice\ndescription: d\n---\nbody"
+	fk.byName["invoice"] = &skills.Skill{SkillBasic: skills.SkillBasic{
+		Name: "invoice", Description: "d", Content: content, Owner: oid.Cast("o1"),
+	}}
+
+	// 非 owner 更新 → 403
+	rr := doSkillReq(r, http.MethodPut, "/api/skills/invoice", `{"description":"x"}`, "o2")
+	if got := respCode(t, rr); got != http.StatusForbidden {
+		t.Errorf("non-owner update code = %d, want 403", got)
+	}
+
+	// owner 更新 → 200
+	rr = doSkillReq(r, http.MethodPut, "/api/skills/invoice", `{"description":"x"}`, "o1")
+	if rr.Code != http.StatusOK {
+		t.Errorf("owner update status = %d, body %s", rr.Code, rr.Body.String())
+	}
+	if fk.byName["invoice"].Description != "x" {
+		t.Errorf("description not updated")
+	}
+
+	// owner 更新超长描述 → 400
+	rr = doSkillReq(r, http.MethodPut, "/api/skills/invoice", `{"description":"`+strings.Repeat("a", 125)+`"}`, "o1")
+	if got := respCode(t, rr); got != http.StatusBadRequest {
+		t.Errorf("long description update code = %d, want 400", got)
+	}
+
+	// 非 owner 删除 → 403；owner 删除 → 200
+	rr = doSkillReq(r, http.MethodDelete, "/api/skills/invoice", "", "o2")
+	if got := respCode(t, rr); got != http.StatusForbidden {
+		t.Errorf("non-owner delete code = %d, want 403", got)
+	}
+	rr = doSkillReq(r, http.MethodDelete, "/api/skills/invoice", "", "o1")
+	if rr.Code != http.StatusOK {
+		t.Errorf("owner delete status = %d, body %s", rr.Code, rr.Body.String())
+	}
+	if _, ok := fk.byName["invoice"]; ok {
+		t.Error("skill should be deleted")
+	}
+}
+
+func TestSkillGetAPI(t *testing.T) {
+	a, fk := skillAPI()
+	r := skillRouter(a)
+	fk.byName["invoice"] = &skills.Skill{SkillBasic: skills.SkillBasic{
+		Name: "invoice", Description: "d", Content: "body", Owner: oid.Cast("o1"),
+	}}
+	rr := doSkillReq(r, http.MethodGet, "/api/skills/invoice", "", "o1")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("get status = %d", rr.Code)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := resp["result"]; !ok {
+		t.Errorf("unexpected response: %s", rr.Body.String())
+	}
+
+	rr = doSkillReq(r, http.MethodGet, "/api/skills/nope", "", "o1")
+	if got := respCode(t, rr); got != http.StatusNotFound {
+		t.Errorf("missing skill code = %d, want 404", got)
+	}
+}


### PR DESCRIPTION
- Store open Agent Skills SKILL.md bundles in DB: skill row (codegen model/store/admin CRUD) + resource files in agent_skill_file (bytea content, mime, text/binary kind, per-file size, composite unique skill_id+path)
- Bundle writes are atomic upserts keyed by (skill_id, path); file access gated by skill visibility; binary content stored but never inlined into LLM context
- System prompt injects metadata only; full content loads on demand: direct injection below threshold, skill_list/skill_read/skill_file_list/skill_file_read embedded tools (same source as REST list), /skill command activation
- Channel visibility (Channel bitmask) + user-facing REST API (owner semantics, description length validation, swagger annotations)
- Tests and plan included (requirements doc lives in gitignored docs/brainstorms)