### PR TITLE
feat(corpus): add async CSV document import

### DIFF
--- a/docs/corpus.yaml
+++ b/docs/corpus.yaml
@@ -1,6 +1,27 @@
 depends:
   comm: github.com/cupogo/andvari/models/comm
   oid: github.com/cupogo/andvari/models/oid
+  time: time
+
+enums:
+
+  - comment: 导入任务状态
+    name: ImportTaskStatus
+    start: 1
+    type: int8
+    values:
+      - label: 排队中
+        suffix: Pending
+      - label: 处理中
+        suffix: Processing
+      - label: 已完成
+        suffix: Succeeded
+      - label: 已失败
+        suffix: Failed
+    stringer: true
+    decodable: true
+    textMarshaler: true
+    textUnmarshaler: true
 
 gename: corpus
 modelpkg: corpus
@@ -116,6 +137,86 @@ models:
       - type: comm.MetaField
     oidcat: event
 
+  - name: ImportTask
+    comment: '文档导入任务'
+    tableTag: 'corpus_import,alias:ci'
+    fields:
+      - type: comm.DefaultModel
+      - comment: 原始文件名
+        name: Filename
+        type: string
+        tags: {json: 'filename', pg: ',notnull,type:varchar(255)'}
+        isset: true
+        query: 'match'
+        sortable: true
+      - comment: 任务状态
+        name: Status
+        type: ImportTaskStatus
+        tags: {json: 'status', pg: ',notnull,type:smallint,default:1'}
+        isset: true
+        query: 'equal'
+        sortable: true
+      - comment: 原始 CSV 内容（worker 读取处理）
+        name: Data
+        type: string
+        tags: {json: 'data,omitempty', pg: ',notnull,type:text'}
+        isset: true
+      - comment: 总数据行数
+        name: Total
+        type: int
+        tags: {json: 'total', pg: ',notnull,default:0'}
+        isset: true
+      - comment: 成功行数
+        name: Success
+        type: int
+        tags: {json: 'success', pg: ',notnull,default:0'}
+        isset: true
+      - comment: 失败行数
+        name: Failed
+        type: int
+        tags: {json: 'failed', pg: ',notnull,default:0'}
+        isset: true
+      - comment: 跳过行数（重复行）
+        name: Skipped
+        type: int
+        tags: {json: 'skipped', pg: ',notnull,default:0'}
+        isset: true
+      - comment: 失败明细
+        name: Errors
+        type: '[]ImportFailure'
+        tags: {json: 'errors,omitempty', pg: ",notnull,type:jsonb,default:'[]'"}
+        isset: true
+      - comment: 开始处理时间
+        name: StartedAt
+        type: '*time.Time'
+        tags: {json: 'startedAt,omitempty', pg: 'started_at,type:timestamptz'}
+        isset: true
+      - comment: 完成时间
+        name: FinishedAt
+        type: '*time.Time'
+        tags: {json: 'finishedAt,omitempty', pg: 'finished_at,type:timestamptz'}
+        isset: true
+      - type: comm.MetaField
+    oidcat: task
+    specNs: cob
+
+  - name: ImportFailure
+    comment: '导入失败明细'
+    fields:
+      - comment: 行号（表头为第 1 行，数据从第 2 行起）
+        name: Line
+        type: int
+        tags: {json: 'line'}
+      - comment: 该行标题
+        name: Title
+        type: string
+        tags: {json: 'title'}
+      - comment: 失败原因
+        name: Reason
+        type: string
+        tags: {json: 'reason'}
+    withPlural: true
+
 stores:
   - name: corpuStore
     embed: CorpuStoreX
@@ -124,6 +225,7 @@ stores:
       - { name: Document, type: LGCUD }
       - { name: DocVector, type: GCD }
       - { name: ChatLog, type: CGLD }
+      - { name: ImportTask, type: LGCUD }
 
 webcode: chi
 webapi:

--- a/docs/plans/2026-08-24-001-feat-import-docs-async-plan.md
+++ b/docs/plans/2026-08-24-001-feat-import-docs-async-plan.md
@@ -1,0 +1,323 @@
+---
+title: feat: ImportDocs 异步导入 API
+type: feat
+status: completed
+date: 2026-08-24
+origin: docs/brainstorms/2026-08-24-import-docs-async-requirements.md
+---
+
+# ImportDocs 异步导入 API
+
+## Summary
+
+通过 `docs/corpus.yaml` 的代码生成建立 `ImportTask` / `ImportFailure` / `ImportTaskStatus` 模型与基础存储方法，在 stores 层实现"任务即队列"的导入执行与串行 worker（含崩溃恢复），并新增三个自定义 API 端点（上传、列表、详情），全部按 Keeper 权限控制。
+
+---
+
+## Problem Frame
+
+当前文档导入只有 CLI，管理后台无法自助上传；导入逐行调用 embedding，耗时长，同步 HTTP 会占住连接且无法反馈进度与失败原因（详见 origin 文档 Problem Frame）。本计划在已确认的单实例部署下，用最小机制解决：任务落 Postgres、进程内串行消费、重启自愈。
+
+---
+
+## Requirements
+
+以下 R-ID 与 origin 文档对应，计划必须满足：
+
+- R1. 上传 CSV 创建任务（初始 pending）；表头不合法或非 UTF-8 直接拒绝
+- R2. CSV 内容随任务持久化，worker 从任务记录读取
+- R3. 进程内串行消费，同一时间一个任务
+- R4. 容错继续：单行失败记录原因跳过、不重试；任务正常结束为已完成
+- R5. 重复行（title+heading 已存在）跳过并记录，不覆盖已有文档
+- R6. 任务记录计数（total/success/failed/skipped）、失败与跳过明细、开始与完成时间
+- R7. 重启后自动恢复 pending/processing 任务，重复处理不产生重复文档
+- R8. 列表按创建倒序、可按状态筛选、不返回 CSV 原文；详情含失败与跳过明细
+- R9. 上传与查询仅 Keeper 角色可访问
+
+**Origin actors:** A1（管理后台用户）、A2（后台 worker）
+**Origin flows:** F1（上传导入）、F2（状态查看）、F3（崩溃恢复）
+**Origin acceptance examples:** AE1（2 行失败仍完成）、AE2（坏表头/非 UTF-8 拒绝）、AE3（重复行跳过且不覆盖）、AE4（崩溃恢复不重复）
+
+---
+
+## Scope Boundaries
+
+- 不做取消任务、并发多任务、实时行级进度推送
+- 不引入 Redis Stream / LISTEN-NOTIFY
+- 不支持多文件/多格式上传
+- 不做失败行重试/重新提交
+- 不做任务完成通知；任务历史保留策略搁置（v1 无自动清理）
+- 不为任务表生成标准 webapi CRUD 端点（上传与查询为自定义 handler）
+
+### Deferred to Follow-Up Work
+
+- 任务历史自动清理/保留策略：后续迭代（任务表持续累积）
+- 失败行重新提交（基于明细重导）：后续迭代
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- 代码生成：`make codegen` 对 `docs/*.yaml` 执行 scaffold codegen（`-spec 7`），生成 `pkg/models/corpus/corpus_gen.go`、`pkg/services/stores/corpus_gen.go`、`pkg/web/api/handle_corpus_gen.go`；手写扩展放在同名 `_x.go` 文件
+- 枚举先例：`pkg/models/convo/convo_gen.go` 的 `SessionStatus`（int8 + start + Decode/String/MarshalText），`ImportTaskStatus` 将同构生成
+- 自定义 handler 先例：`pkg/web/api/handle_convo.go` 用 `init()` + `regHI(auth, method, path, rid, ...)` 注册；响应用 `success`/`fail`；查询绑定用 `queryBinder`；Keeper 校验可参考 `pkg/web/api/api.go` 的 `authPerm`（`stores.IsKeeper`，403）或直接在 handler 内检查
+- 导入链路：`pkg/services/stores/corpus_x.go` 的 `ImportDocs`/`importLine`/`validHead`/`CreateDocument`/`afterCreatedCobDocument`/`GetEmbedding`；重复语义为"更新"，本功能需新写"跳过"分支，不动 CLI
+- 存储接口：`pkg/services/stores/interfaces.go` 的 `CorpuStore` 通过 `embed CorpuStoreX` 扩展手写方法
+- 测试先例：`pkg/services/stores/integration_test.go`（`-tags=integration`，真实 PG + `mockEmbeddingClient`）；`pkg/web/api/skill_user_test.go`（内存 fake store 的 handler 测试）
+- 启动接线：`main.go` 的 `webRun`（`stores.InitDB` → `web.New` → `srv.Serve`，信号 goroutine 调 `srv.Stop`）
+
+### Institutional Learnings
+
+- `docs/solutions/` 现有两条（工具循环去重、流式 StartStream 重复）与本功能无直接冲突；仓库尚无异步任务/worker 先例，本计划是第一个，模式保持最小
+
+### External References
+
+- 无（本地模式充分，未做外部调研）
+
+---
+
+## Key Technical Decisions
+
+- [生成 + 手写扩展的边界]: 模型、枚举、基础 LGCUD 与 `CobImportTaskSpec` 由 codegen 生成；导入执行、轻量列表、worker 循环、API handler 为手写 x/新文件
+- [任务状态判定]: 只有 CSV 解析失败（csv.Reader 中途出错）将任务标记为 failed；行级失败（含 100% 行失败）任务仍为 succeeded（用户已确认）
+- [重复行跳过]: 处理每行前按 title+heading 查重，已存在则 Skipped++ 并记明细；不修改 CLI 的"更新"语义
+- [认领与恢复]: 单个任务处理前原子更新 status=pending→processing（记录 StartedAt）；启动时先把遗留 processing 任务置回 pending 再开始循环
+- [上传校验]: 同步完成大小上限（10 MiB，超限 413）、UTF-8 校验（非 UTF-8 拒绝）、BOM 剥离、表头校验；数据行校验在 worker 内容错继续
+- [CSV 原文不进响应]: 列表与详情均不返回 `Data` 字段；列表同时不返回 `Errors`（明细仅详情返回），避免大失败批次拖慢列表
+- [行分类规则]: 非表头行全部计入 `Total`；空行/缺字段等无效行记 `Failed`（reason 为"数据无效"），保证 `Total = Success + Failed + Skipped` 恒成立。与 CLI 的"空行静默跳过"不同，API 对界面透明，且与 AE1（100 行=98 成功+2 失败）一致
+- [明细体积上限]: 失败/跳过明细最多保留 500 条、reason 截断至 200 字符；计数仍精确，超限部分不丢失汇总信息
+- [端点形状]: `POST /api/corpus/imports`（multipart 上传）、`GET /api/corpus/imports`（列表）、`GET /api/corpus/imports/{id}`（详情）；Keeper 权限经 rid 触发 `authPerm`，与现有 corpus PUT/DELETE 端点一致
+- [worker 可测性]: worker 面向小接口（claim/process/recover）编程，用 fake 做单元测试；真实流程用集成测试覆盖
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- 任务状态判定规则：仅 CSV 解析失败 → failed（已确认）
+- 上传上限：10 MiB（已确认）
+- 列表/详情是否返回 CSV 原文：均不返回（已确认）
+- 失败/跳过明细条数上限与 reason 截断：明细最多 500 条、reason 200 字符（规划期裁定）
+- 空行/无效行的分类：计入 Failed，Total 恒等于三计数之和（规划期裁定，见 Key Technical Decisions）
+
+### Deferred to Implementation
+
+- `*time.Time` 在 codegen 的实际输出形态：若生成异常，回退为 `time.Time`（零值表示未开始）并同步调整 `docs/corpus.yaml`
+- 轻量列表的具体列选择/查询写法：实现时以"不含 Data 列"为准，复用生成的 `CobImportTaskSpec` 做状态筛选与排序
+- 列表"不含 Data/Errors"用列选择还是响应剔除：实现时二选一，行为一致即可
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+stateDiagram-v2
+    [*] --> pending : 上传校验通过，创建任务（含 CSV 原文）
+    pending --> processing : worker 原子认领（记 StartedAt）
+    processing --> succeeded : 全部行处理完（含失败/跳过行）
+    processing --> failed : CSV 解析中途出错
+    processing --> pending : 崩溃后启动扫描（恢复）
+    succeeded --> [*]
+    failed --> [*]
+```
+
+worker 循环（进程内单 goroutine）：
+
+```text
+启动:
+  1. 恢复：遗留 processing 任务 → pending
+  2. 循环:
+     a. 认领最早的 pending 任务（pending → processing）
+     b. 无任务则短暂休眠后重试
+     c. 有任务则处理：解析 CSV → 逐行（查重/导入/计数/记明细）→ 写回计数与状态
+  3. ctx 取消时退出
+```
+
+---
+
+## Implementation Units
+
+### U1. 生成 ImportTask 模型、枚举与基础存储
+
+**Goal:** 通过 codegen 落地 `ImportTask` / `ImportFailure` / `ImportTaskStatus` 及基础 store 方法（含 `CobImportTaskSpec`），仓库可编译。
+
+**Requirements:** R1, R6, R8（数据结构与查询规格基础）
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `docs/corpus.yaml`（已有 ImportTask/ImportFailure/ImportTaskStatus；`time` 依赖已补）
+- Generated: `pkg/models/corpus/corpus_gen.go`、`pkg/services/stores/corpus_gen.go`、`pkg/web/api/handle_corpus_gen.go`（`make codegen` 产出，勿手改）
+- Test: `pkg/models/corpus/import_task_test.go`
+
+**Approach:**
+- 运行 `make codegen` 重新生成 corpus 相关文件；确认 `ImportTaskStatus` 枚举（pending=1/processing=2/succeeded=3/failed=4）、`ImportTask` 模型字段（含 `*time.Time` 的 StartedAt/FinishedAt）、`CobImportTaskSpec` 与 LGCUD 方法生成正确
+- 若 `*time.Time` 生成异常，按 Open Questions 回退为 `time.Time` 并更新 yaml
+- 检查 `handle_corpus_gen.go` 除既有 Document 端点外不新增路由（webapi uris 未含 ImportTask）
+
+**Patterns to follow:**
+- 枚举形态：`pkg/models/convo/convo_gen.go` 的 `SessionStatus`
+- 模型/存储生成：既有 `Document`/`ChatLog` 生成代码
+
+**Test scenarios:**
+- Happy path: `ImportTaskStatus` 四个常量值依次为 1-4，`String()` 返回 `pending/processing/succeeded/failed`
+- Edge case: `Decode` 接受 `"1"`、小写、首字母大写形式，拒绝非法字符串并返回错误
+- Integration: `MarshalText`/`UnmarshalText` 往返一致
+
+**Verification:**
+- `make codegen` 成功、`make vet` 通过；生成代码中枚举与模型字段符合预期；`go test ./pkg/models/...` 通过
+
+---
+
+### U2. 导入执行逻辑（store x 扩展）
+
+**Goal:** 在 stores 层实现单个任务的处理：解析 CSV、逐行查重/导入/计数、失败与跳过明细、状态与时间戳写回，以及恢复扫描方法。
+
+**Requirements:** R2, R4, R5, R6, R7
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `pkg/services/stores/corpus_x.go`（`CorpuStoreX` 接口 + 实现）
+- Modify: `pkg/services/stores/integration_test.go` 或新增 `pkg/services/stores/import_task_test.go`（`-tags=integration`）
+
+**Approach:**
+- 新增 x-store 方法：认领（pending→processing + StartedAt，原子更新）、处理单任务（解析 `Data`、逐行处理、写回计数/Errors/FinishedAt/状态）、恢复（processing→pending）
+- 逐行分类：非表头行全部计入 Total；空行/缺字段/非法值 → Failed（reason"数据无效"）；按 title+heading 查重 → Skipped；否则 CreateDocument（复用现有 embedding 链路），失败 → Failed。明细追加时遵守 500 条上限与 200 字符 reason 截断
+- 仅当 csv.Reader 中途返回非 EOF 错误时任务置 failed；其余情况 succeeded
+- 现有 CLI `ImportDocs`/`importLine` 不改动
+- 集成测试通过包级 embedding 客户端注入（先例：`pkg/services/stores/integration_test.go` 的 `init()` 直接赋值 `llmEm`）注入"指定行失败"的 mock，验证行级错误路径
+
+**Patterns to follow:**
+- CSV 解析/表头：`pkg/services/stores/corpus_x.go` 的 `ImportDocs`/`validHead`
+- 查重与创建：`importLine` 的按 title+heading 查询 + `CreateDocument`
+- 测试基建：`pkg/services/stores/integration_test.go` 的 `mockEmbeddingClient`、包级 `llmEm` 注入与 DB 环境变量（`M_TEST_DB_*`）
+
+**Test scenarios:**
+- Happy path: 3 行合法 CSV → succeeded，Total=3/Success=3，文档与向量落库（Covers AE1 的完成路径）
+- Edge case: 空文件/仅表头 → succeeded，计数全 0
+- Edge case: 同文件内重复 title+heading → 第二次出现被跳过（Skipped=1）
+- Edge case: 文件含空行/缺字段行 → 计入 Total 且记 Failed（reason"数据无效"），Success+Failed+Skipped == Total
+- Error path: 行缺字段 → 失败明细含行号/标题/原因，其余行继续（Covers AE1）
+- Error path: mock embedding 对特定行返回错误 → 该行失败，任务仍 succeeded
+- Error path: CSV 中途 malformed（如引号未闭合）→ 任务 failed
+- Error path: 失败行数超过 500 → 计数精确、明细截断至 500 条，reason 超长被截断
+- Integration: 预置已有文档，重复行跳过且内容不被覆盖（Covers AE3）；恢复方法把 processing 任务置回 pending（Covers AE4 前半）
+
+**Verification:**
+- `make test-stores`（`-tags=integration`）通过；任务字段（计数、Errors JSONB、时间戳）往返正确
+
+---
+
+### U3. 串行 worker 生命周期与启动接线
+
+**Goal:** 进程内单 goroutine 串行消费任务：启动时恢复、循环认领/处理、ctx 取消退出；并在 `main.go` 接线启动。
+
+**Requirements:** R3, R7
+
+**Dependencies:** U2
+
+**Files:**
+- Create: `pkg/services/stores/import_worker.go`
+- Test: `pkg/services/stores/import_worker_test.go`
+- Modify: `main.go`（`webRun` 中启动 worker goroutine，信号时取消 ctx）
+
+**Approach:**
+- worker 面向最小接口（claim / process / recover）编程，便于 fake 单测；循环内无任务时短休眠，避免空转
+- 启动先调 recover，再进入消费循环
+- `webRun` 在 `InitDB` 后创建带取消的 worker ctx：信号 goroutine 收到 SIGINT/SIGTERM 时取消，worker 优雅退出；HTTP 服务停止逻辑保持不变
+
+**Patterns to follow:**
+- 进程内 goroutine 生命周期：`main.go` 现有信号处理结构
+- stores 包内自包含的 worker 类型（依赖 `corpuStore`）
+
+**Test scenarios:**
+- Happy path: fake store 返回一个 pending 任务 → worker 依次 claim/process，一次一个
+- Edge case: 队列为空 → worker 等待不崩溃，新任务出现后被消费
+- Edge case: 启动时存在 processing 遗留任务 → 先恢复为 pending 再消费（Covers AE4）
+- Error path: process 返回错误（非 CSV 解析类）→ worker 记录日志并继续，任务状态由恢复机制兜底；CSV 解析类错误 → 任务 failed
+- Integration: ctx 取消后循环退出，无 goroutine 泄漏
+
+**Verification:**
+- 单测通过；`make vet` 通过；手工/集成验证 worker 随服务启动
+
+---
+
+### U4. 上传与查询 API 端点
+
+**Goal:** 提供 Keeper 权限的 `POST /api/corpus/imports`（multipart 上传）、`GET /api/corpus/imports`（列表）、`GET /api/corpus/imports/{id}`（详情），并生成 swagger 文档。
+
+**Requirements:** R1, R8, R9
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Create: `pkg/web/api/handle_corpus_import.go`
+- Test: `pkg/web/api/handle_corpus_import_test.go`
+
+**Approach:**
+- `init()` + `regHI(true, path, rid, ...)` 注册三个路由，rid 触发 `a.authPerm`（`stores.IsKeeper`，403），与现有 corpus PUT/DELETE 端点同一 keeper 校验模式
+- 上传：`r.FormFile` 取文件 → 大小上限（10 MiB，`http.MaxBytesReader` → 413）→ UTF-8 校验 + BOM 剥离 → 表头校验（复用 stores 导出的校验 helper）→ 创建 pending 任务 → 返回任务对象（不含 Data/Errors）
+- 列表：复用 `CobImportTaskSpec`（状态筛选、按创建倒序、分页），响应不含 Data 与 Errors；详情：按 ID 查询，返回计数与明细，响应剔除 Data
+- 新增 swagger 注解，最后 `make gen-apidoc` 更新 `docs/swagger.yaml`
+
+**Patterns to follow:**
+- 自定义路由：`pkg/web/api/handle_convo.go` 的 `init()`/`regHI`
+- 响应与绑定：`success`/`fail`、`queryBinder`
+- handler 测试：`pkg/web/api/skill_user_test.go` 的内存 fake store
+
+**Test scenarios:**
+- Happy path: 合法 multipart CSV → 2xx 返回任务对象（pending、含 Filename、不含 Data），store 收到剥离 BOM 后的原文（Covers AE2 的通过路径）
+- Error path: 非 UTF-8 文件 → 400 且不创建任务（Covers AE2）
+- Error path: 坏表头 → 400 且不创建任务（Covers AE2）
+- Error path: 超过 10 MiB → 413
+- Error path: 未登录 → 401；非 Keeper → 403；缺失文件字段 → 400
+- Happy path: 列表按创建倒序返回、不含 Data 与 Errors、可按状态筛选；详情返回计数与明细
+- Error path: 不存在的任务 ID → 404；列表/详情非 Keeper → 403
+
+**Verification:**
+- handler 测试通过；`make gen-apidoc` 后 `docs/swagger.yaml` 含新端点；`make vet lint` 通过
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** 新增三个 `/api/corpus/imports` 路由；worker goroutine 随 `webRun` 启动；`CorpuStoreX` 接口扩展
+- **Error propagation:** 上传期错误以 4xx 直接返回；任务处理期错误落入任务明细/状态，不向调用方扩散
+- **State lifecycle risks:** 认领后崩溃靠启动恢复（processing→pending）；行级幂等（按 title+heading 跳过）保证重跑不重复；CSV 原文只在任务记录内，不泄露到响应
+- **API surface parity:** 现有 `/api/corpus/documents` 端点与 CLI `import-docs` 行为不变
+- **Integration coverage:** 上传→worker 消费→状态查询的端到端链路由集成测试（真实 PG + fake embedding）覆盖
+- **Unchanged invariants:** CLI 导入的"重复则更新"语义不变；KBCreate 工具行为不变；Redis 职责不变
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| codegen 对新增模型/枚举生成异常（如 `*time.Time`） | U1 先行验证，异常则回退 `time.Time` 并同步 yaml |
+| codegen 重新生成影响既有文件 | `make codegen` 后跑 `make vet` + 全量测试确认无回归 |
+| embedding 服务故障导致整批失败 | 按已确认规则任务仍 succeeded 并暴露明细；系统性故障靠日志与任务明细发现 |
+| 大失败批次导致 Errors JSONB 过大 | 明细截断至 500 条、reason 200 字符，计数保持精确；列表不返回 Errors |
+| worker 与 HTTP 生命周期不同步 | `webRun` 统一 ctx，信号取消时 worker 退出 |
+
+---
+
+## Documentation / Operational Notes
+
+- `make gen-apidoc` 更新 `docs/swagger.yaml` 以包含新端点
+- 无新增环境变量；上传上限 10 MiB 以常量实现，后续如需可迁入 `pkg/settings`
+- 发布后观察：任务明细中的系统性失败模式（如大量 embedding 失败）可通过日志定位
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-08-24-import-docs-async-requirements.md](docs/brainstorms/2026-08-24-import-docs-async-requirements.md)
+- Related code: `pkg/services/stores/corpus_x.go`、`pkg/web/api/handle_convo.go`、`main.go`、`docs/corpus.yaml`
+- Enum precedent: `pkg/models/convo/convo_gen.go`

--- a/docs/residual-review-findings/462990182008f52643cb9a63f07ccab6f2f3fbbb.md
+++ b/docs/residual-review-findings/462990182008f52643cb9a63f07ccab6f2f3fbbb.md
@@ -1,0 +1,52 @@
+# Known Residuals — feat/import-docs-async
+
+> Accepted residual findings from the Tier 2 code review (ce-code-review, autofix mode) on commit `4629901` (branch `feat/import-docs-async`). User decision: **Accept and proceed** — these items are intentionally not fixed in this change and are tracked here for follow-up.
+
+**Review run:** `20260825-123339-e8d57f5b`
+**Artifact:** `/tmp/compound-engineering/ce-code-review/20260825-123339-e8d57f5b/`
+**Verdict at review time:** Ready with fixes (all findings P3; no P0/P1/P2).
+
+## Residual Actionable Work
+
+### F1 — Upload filename longer than varchar(255) fails with 503
+
+- **Severity:** P3 · **Route:** `gated_auto -> downstream-resolver` · **Confidence:** 100
+- **File:** `pkg/web/api/handle_corpus_import.go:72`
+- **Issue:** `fh.Filename` is user-controlled multipart metadata stored unvalidated into a `varchar(255)` column. A filename longer than 255 characters (or 255 multibyte runes) makes `CreateImportTask` fail with a PostgreSQL "value too long" error, surfacing as 503 with no task created.
+- **Suggested fix:** Truncate the filename to 255 runes (or reject with 400) before `CreateImportTask`; add a handler test for the boundary.
+- **Requires verification:** yes (test).
+
+### F2 — Import list without limit/page returns all tasks and total=0
+
+- **Severity:** P3 · **Route:** `gated_auto -> downstream-resolver` · **Confidence:** 75
+- **File:** `pkg/web/api/handle_corpus_import.go:139`
+- **Issue:** `QueryPager` only applies `ScanAndCount` when `limit > 0` (or `page > 0`). With no limit/page params the list endpoint scans every import task and reports `total = 0`. The task table has no cleanup (explicitly deferred), so responses grow unboundedly over time.
+- **Suggested fix:** Default `spec.Limit` to 20 when both `limit` and `page` are absent so the response is bounded and `total` is accurate.
+- **Requires verification:** yes (test against the real `QueryPager` path).
+
+### F3 — Import detail loads full CSV column only to strip it from the response
+
+- **Severity:** P3 · **Route:** `manual -> downstream-resolver` · **Confidence:** 75
+- **File:** `pkg/services/stores/corpus_gen.go:213`
+- **Issue:** `GetImportTask` selects all columns including `data` (up to the 10 MiB upload cap); the handler then builds a DTO that omits it. Every detail request transfers the full CSV from Postgres for nothing.
+- **Suggested fix:** Add a detail-store method (or column-exclusion path) that selects all columns except `data`.
+
+### F5 — Worker goroutine has no panic recovery; a DB panic crashes the process
+
+- **Severity:** P3 · **Route:** `gated_auto -> downstream-resolver` · **Confidence:** 75
+- **File:** `pkg/services/stores/import_worker.go:41`
+- **Issue:** The worker runs in a bare goroutine. andvari's query helpers panic on `ErrBadConn` (see `oneWithOrder`); any such panic inside claim/process propagates out of `Run` and kills the process. HTTP handlers are protected by chi's recoverer; the worker is not. Restart recovery absorbs the impact (crash → restart → processing tasks reset to pending).
+- **Suggested fix:** Wrap the `Run` loop body in a deferred recover that logs and continues, or explicitly keep crash-driven restart recovery as the intended safety net.
+
+## Advisory (not actionable code work)
+
+### F4 — Embedding-failure rows leave documents without vectors while counted as failed
+
+- **Severity:** P3 · **Route:** `advisory -> human` · **Confidence:** 75
+- **File:** `pkg/services/stores/corpus_x.go:314`
+- **Note:** `CreateDocument` persists the row before the embedding call; on embedding failure the row is counted as Failed but the document exists without a vector, and a crash-recovery re-run then skips the row as a duplicate. Ops should read task details with this in mind.
+
+## Residual Risks (from review)
+
+- Task rows stay `processing` forever if the process never restarts after a mid-processing error (recovery only runs at startup).
+- No rate limiting on the upload endpoint (the app limiter only wraps `/chat`); mitigated by keeper-only access.

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1845,6 +1845,713 @@
                 }
             }
         },
+        "/api/corpus/documents": {
+            "get": {
+                "description": "\u003csortable\u003eid,created,updated,heading\u003c/sortable\u003e",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "默认 文档生成"
+                ],
+                "summary": "查询 文档 列表",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "登录票据凭证",
+                        "name": "token",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "aaa,bbb,ccc",
+                        "x-order": "0",
+                        "description": "主键编号`ids`（以逗号分隔的字串），仅供 Form 或 Query 使用, example:\"aaa,bbb,ccc\"",
+                        "name": "ids",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "2",
+                        "description": "创建者ID",
+                        "name": "creatorID",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "3",
+                        "description": "创建时间 形式： yyyy-mm-dd, 1_day, 2_weeks, 3_months",
+                        "name": "created",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "4",
+                        "description": "更新时间 形式： yyyy-mm-dd, 1_day, 2_weeks, 3_months",
+                        "name": "updated",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "x-order": "5",
+                        "description": "IsDelete 查询删除的记录",
+                        "name": "isDelete",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "A",
+                        "description": "主标题 名称",
+                        "name": "title",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "B",
+                        "description": "小节标题 属性 类别",
+                        "name": "heading",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "C",
+                        "description": "内容 值",
+                        "name": "content",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "example": 1,
+                        "x-order": "[",
+                        "description": "第几页",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "x-order": "]",
+                        "description": "跳过多少条记录，如果提供 page 此项跳过",
+                        "name": "skip",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "x-order": "_",
+                        "description": "分页大小，默认20",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "|",
+                        "description": "排序，允许最多两个字段排序 field1 [asc | desc] [,field2 [asc | desc] ...]",
+                        "name": "sort",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.Done"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "result": {
+                                            "allOf": [
+                                                {
+                                                    "$ref": "#/definitions/api.ResultData"
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "data": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "$ref": "#/definitions/corpusDocument"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "请求或参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "401": {
+                        "description": "未登录",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "404": {
+                        "description": "目标未找到",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "503": {
+                        "description": "服务端错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/corpus/documents/{id}": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "默认 文档生成"
+                ],
+                "summary": "获取 文档 详情",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "登录票据凭证",
+                        "name": "token",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "编号",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.Done"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "result": {
+                                            "$ref": "#/definitions/corpusDocument"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "请求或参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "401": {
+                        "description": "未登录",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "404": {
+                        "description": "目标未找到",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "503": {
+                        "description": "服务端错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "consumes": [
+                    "application/json",
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "默认 文档生成"
+                ],
+                "summary": "更新 文档 🔑",
+                "operationId": "corpus-documents-id-put",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "登录票据凭证",
+                        "name": "token",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "编号",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Object",
+                        "name": "query",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/corpusDocumentSet"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.Done"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "result": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "请求或参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "401": {
+                        "description": "未登录",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "403": {
+                        "description": "无权限",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "503": {
+                        "description": "服务端错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "默认 文档生成"
+                ],
+                "summary": "删除 文档 🔑",
+                "operationId": "corpus-documents-id-delete",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "登录票据凭证",
+                        "name": "token",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "编号",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.Done"
+                        }
+                    },
+                    "400": {
+                        "description": "请求或参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "401": {
+                        "description": "未登录",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "403": {
+                        "description": "无权限",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "503": {
+                        "description": "服务端错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/corpus/imports": {
+            "get": {
+                "description": "\u003csortable\u003ecreated,filename,status\u003c/sortable\u003e",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "语料 文档导入"
+                ],
+                "summary": "查询导入任务列表 🔑",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "登录票据凭证",
+                        "name": "token",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "aaa,bbb,ccc",
+                        "x-order": "0",
+                        "description": "主键编号`ids`（以逗号分隔的字串），仅供 Form 或 Query 使用, example:\"aaa,bbb,ccc\"",
+                        "name": "ids",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "2",
+                        "description": "创建者ID",
+                        "name": "creatorID",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "3",
+                        "description": "创建时间 形式： yyyy-mm-dd, 1_day, 2_weeks, 3_months",
+                        "name": "created",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "4",
+                        "description": "更新时间 形式： yyyy-mm-dd, 1_day, 2_weeks, 3_months",
+                        "name": "updated",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "x-order": "5",
+                        "description": "IsDelete 查询删除的记录",
+                        "name": "isDelete",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "A",
+                        "description": "原始文件名",
+                        "name": "filename",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "B",
+                        "description": "任务状态\n * `pending` - 排队中\n * `processing` - 处理中\n * `succeeded` - 已完成\n * `failed` - 已失败",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "example": 1,
+                        "x-order": "[",
+                        "description": "第几页",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "x-order": "]",
+                        "description": "跳过多少条记录，如果提供 page 此项跳过",
+                        "name": "skip",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "x-order": "_",
+                        "description": "分页大小，默认20",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "x-order": "|",
+                        "description": "排序，允许最多两个字段排序 field1 [asc | desc] [,field2 [asc | desc] ...]",
+                        "name": "sort",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.Done"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "result": {
+                                            "allOf": [
+                                                {
+                                                    "$ref": "#/definitions/api.ResultData"
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "data": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "$ref": "#/definitions/api.corpusImportTaskView"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "请求或参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "401": {
+                        "description": "未登录",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "403": {
+                        "description": "无权限",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "503": {
+                        "description": "服务端错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "语料 文档导入"
+                ],
+                "summary": "上传 CSV 创建导入任务 🔑",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "登录票据凭证",
+                        "name": "token",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "CSV 文件（title,heading,content，UTF-8）",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.Done"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "result": {
+                                            "$ref": "#/definitions/api.corpusImportTaskView"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "请求或参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "401": {
+                        "description": "未登录",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "403": {
+                        "description": "无权限",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "413": {
+                        "description": "文件过大",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "503": {
+                        "description": "服务端错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/corpus/imports/{id}": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "语料 文档导入"
+                ],
+                "summary": "获取导入任务详情 🔑",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "登录票据凭证",
+                        "name": "token",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "任务ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.Done"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "result": {
+                                            "$ref": "#/definitions/api.corpusImportTaskView"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "请求或参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "401": {
+                        "description": "未登录",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "403": {
+                        "description": "无权限",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "404": {
+                        "description": "目标未找到",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    },
+                    "503": {
+                        "description": "服务端错误",
+                        "schema": {
+                            "$ref": "#/definitions/api.Failure"
+                        }
+                    }
+                }
+            }
+        },
         "/api/history/{cid}": {
             "get": {
                 "consumes": [
@@ -3505,6 +4212,50 @@
                 }
             }
         },
+        "api.corpusImportTaskView": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "errors": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/corpusImportFailure"
+                    }
+                },
+                "failed": {
+                    "type": "integer"
+                },
+                "filename": {
+                    "type": "string"
+                },
+                "finishedAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "skipped": {
+                    "type": "integer"
+                },
+                "startedAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/corpus.ImportTaskStatus"
+                },
+                "success": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
         "api.respSession": {
             "type": "object",
             "properties": {
@@ -3513,6 +4264,10 @@
                     "properties": {
                         "auth": {
                             "description": "need auth",
+                            "type": "boolean"
+                        },
+                        "keeper": {
+                            "description": "user is keeper",
                             "type": "boolean"
                         },
                         "model": {
@@ -3959,6 +4714,123 @@
                 }
             }
         },
+        "corpus.ImportTaskStatus": {
+            "type": "integer",
+            "format": "int32",
+            "enum": [
+                1,
+                2,
+                3,
+                4
+            ],
+            "x-enum-comments": {
+                "ImportTaskStatusFailed": "4 已失败",
+                "ImportTaskStatusPending": "1 排队中",
+                "ImportTaskStatusProcessing": "2 处理中",
+                "ImportTaskStatusSucceeded": "3 已完成"
+            },
+            "x-enum-descriptions": [
+                "1 排队中",
+                "2 处理中",
+                "3 已完成",
+                "4 已失败"
+            ],
+            "x-enum-varnames": [
+                "ImportTaskStatusPending",
+                "ImportTaskStatusProcessing",
+                "ImportTaskStatusSucceeded",
+                "ImportTaskStatusFailed"
+            ]
+        },
+        "corpusDocument": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "description": "创建时间",
+                    "type": "string",
+                    "x-order": ""
+                },
+                "id": {
+                    "description": "主键",
+                    "type": "string",
+                    "x-order": "!"
+                },
+                "updatedAt": {
+                    "description": "变更时间",
+                    "type": "string",
+                    "x-order": "."
+                },
+                "title": {
+                    "description": "主标题 名称",
+                    "type": "string",
+                    "x-order": "A"
+                },
+                "heading": {
+                    "description": "小节标题 属性 类别",
+                    "type": "string",
+                    "x-order": "B"
+                },
+                "content": {
+                    "description": "内容 值",
+                    "type": "string",
+                    "x-order": "C"
+                },
+                "creatorID": {
+                    "description": "创建者ID",
+                    "type": "string",
+                    "x-order": "_"
+                },
+                "meta": {
+                    "description": "Meta 元信息",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Meta"
+                        }
+                    ],
+                    "x-order": "|"
+                }
+            }
+        },
+        "corpusDocumentSet": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "description": "主标题 名称",
+                    "type": "string",
+                    "x-order": "A"
+                },
+                "heading": {
+                    "description": "小节标题 属性 类别",
+                    "type": "string",
+                    "x-order": "B"
+                },
+                "content": {
+                    "description": "内容 值",
+                    "type": "string",
+                    "x-order": "C"
+                }
+            }
+        },
+        "corpusImportFailure": {
+            "type": "object",
+            "properties": {
+                "line": {
+                    "description": "行号（表头为第 1 行，数据从第 2 行起）",
+                    "type": "integer",
+                    "x-order": "A"
+                },
+                "title": {
+                    "description": "该行标题",
+                    "type": "string",
+                    "x-order": "B"
+                },
+                "reason": {
+                    "description": "失败原因",
+                    "type": "string",
+                    "x-order": "C"
+                }
+            }
+        },
         "mcps.ToolDescriptor": {
             "type": "object",
             "properties": {
@@ -4264,11 +5136,11 @@
                     "x-order": "D"
                 },
                 "kind": {
-                    "description": "文件类型\n * `binary` - 二进制\n * `text` - 文本",
+                    "description": "文件类型\n * `text` - 文本\n * `binary` - 二进制",
                     "type": "string",
                     "enum": [
-                        "binary",
-                        "text"
+                        "text",
+                        "binary"
                     ],
                     "x-order": "E"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1197,6 +1197,467 @@ paths:
           description: 服务端错误
           schema:
             $ref: '#/definitions/api.Failure'
+  /api/corpus/documents:
+    get:
+      description: <sortable>id,created,updated,heading</sortable>
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - 默认 文档生成
+      summary: 查询 文档 列表
+      parameters:
+        - type: string
+          description: 登录票据凭证
+          name: token
+          in: header
+          required: true
+        - type: string
+          example: aaa,bbb,ccc
+          x-order: "0"
+          description: 主键编号`ids`（以逗号分隔的字串），仅供 Form 或 Query 使用, example:"aaa,bbb,ccc"
+          name: ids
+          in: query
+        - type: string
+          x-order: "2"
+          description: 创建者ID
+          name: creatorID
+          in: query
+        - type: string
+          x-order: "3"
+          description: 创建时间 形式： yyyy-mm-dd, 1_day, 2_weeks, 3_months
+          name: created
+          in: query
+        - type: string
+          x-order: "4"
+          description: 更新时间 形式： yyyy-mm-dd, 1_day, 2_weeks, 3_months
+          name: updated
+          in: query
+        - type: boolean
+          x-order: "5"
+          description: IsDelete 查询删除的记录
+          name: isDelete
+          in: query
+        - type: string
+          x-order: A
+          description: 主标题 名称
+          name: title
+          in: query
+        - type: string
+          x-order: B
+          description: 小节标题 属性 类别
+          name: heading
+          in: query
+        - type: string
+          x-order: C
+          description: 内容 值
+          name: content
+          in: query
+        - type: integer
+          example: 1
+          x-order: '['
+          description: 第几页
+          name: page
+          in: query
+        - type: integer
+          x-order: ']'
+          description: 跳过多少条记录，如果提供 page 此项跳过
+          name: skip
+          in: query
+        - type: integer
+          x-order: _
+          description: 分页大小，默认20
+          name: limit
+          in: query
+        - type: string
+          x-order: '|'
+          description: 排序，允许最多两个字段排序 field1 [asc | desc] [,field2 [asc | desc] ...]
+          name: sort
+          in: query
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+              - $ref: '#/definitions/api.Done'
+              - type: object
+                properties:
+                  result:
+                    allOf:
+                      - $ref: '#/definitions/api.ResultData'
+                      - type: object
+                        properties:
+                          data:
+                            type: array
+                            items:
+                              $ref: '#/definitions/corpusDocument'
+        "400":
+          description: 请求或参数错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "401":
+          description: 未登录
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "404":
+          description: 目标未找到
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "503":
+          description: 服务端错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+  /api/corpus/documents/{id}:
+    get:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - 默认 文档生成
+      summary: 获取 文档 详情
+      parameters:
+        - type: string
+          description: 登录票据凭证
+          name: token
+          in: header
+          required: true
+        - type: string
+          description: 编号
+          name: id
+          in: path
+          required: true
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+              - $ref: '#/definitions/api.Done'
+              - type: object
+                properties:
+                  result:
+                    $ref: '#/definitions/corpusDocument'
+        "400":
+          description: 请求或参数错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "401":
+          description: 未登录
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "404":
+          description: 目标未找到
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "503":
+          description: 服务端错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+    put:
+      consumes:
+        - application/json
+        - multipart/form-data
+      produces:
+        - application/json
+      tags:
+        - 默认 文档生成
+      summary: "更新 文档 \U0001F511"
+      operationId: corpus-documents-id-put
+      parameters:
+        - type: string
+          description: 登录票据凭证
+          name: token
+          in: header
+          required: true
+        - type: string
+          description: 编号
+          name: id
+          in: path
+          required: true
+        - description: Object
+          name: query
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/corpusDocumentSet'
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+              - $ref: '#/definitions/api.Done'
+              - type: object
+                properties:
+                  result:
+                    type: string
+        "400":
+          description: 请求或参数错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "401":
+          description: 未登录
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "403":
+          description: 无权限
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "503":
+          description: 服务端错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+    delete:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - 默认 文档生成
+      summary: "删除 文档 \U0001F511"
+      operationId: corpus-documents-id-delete
+      parameters:
+        - type: string
+          description: 登录票据凭证
+          name: token
+          in: header
+          required: true
+        - type: string
+          description: 编号
+          name: id
+          in: path
+          required: true
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.Done'
+        "400":
+          description: 请求或参数错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "401":
+          description: 未登录
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "403":
+          description: 无权限
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "503":
+          description: 服务端错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+  /api/corpus/imports:
+    get:
+      description: <sortable>created,filename,status</sortable>
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - 语料 文档导入
+      summary: "查询导入任务列表 \U0001F511"
+      parameters:
+        - type: string
+          description: 登录票据凭证
+          name: token
+          in: header
+          required: true
+        - type: string
+          example: aaa,bbb,ccc
+          x-order: "0"
+          description: 主键编号`ids`（以逗号分隔的字串），仅供 Form 或 Query 使用, example:"aaa,bbb,ccc"
+          name: ids
+          in: query
+        - type: string
+          x-order: "2"
+          description: 创建者ID
+          name: creatorID
+          in: query
+        - type: string
+          x-order: "3"
+          description: 创建时间 形式： yyyy-mm-dd, 1_day, 2_weeks, 3_months
+          name: created
+          in: query
+        - type: string
+          x-order: "4"
+          description: 更新时间 形式： yyyy-mm-dd, 1_day, 2_weeks, 3_months
+          name: updated
+          in: query
+        - type: boolean
+          x-order: "5"
+          description: IsDelete 查询删除的记录
+          name: isDelete
+          in: query
+        - type: string
+          x-order: A
+          description: 原始文件名
+          name: filename
+          in: query
+        - type: string
+          x-order: B
+          description: |-
+            任务状态
+             * `pending` - 排队中
+             * `processing` - 处理中
+             * `succeeded` - 已完成
+             * `failed` - 已失败
+          name: status
+          in: query
+        - type: integer
+          example: 1
+          x-order: '['
+          description: 第几页
+          name: page
+          in: query
+        - type: integer
+          x-order: ']'
+          description: 跳过多少条记录，如果提供 page 此项跳过
+          name: skip
+          in: query
+        - type: integer
+          x-order: _
+          description: 分页大小，默认20
+          name: limit
+          in: query
+        - type: string
+          x-order: '|'
+          description: 排序，允许最多两个字段排序 field1 [asc | desc] [,field2 [asc | desc] ...]
+          name: sort
+          in: query
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+              - $ref: '#/definitions/api.Done'
+              - type: object
+                properties:
+                  result:
+                    allOf:
+                      - $ref: '#/definitions/api.ResultData'
+                      - type: object
+                        properties:
+                          data:
+                            type: array
+                            items:
+                              $ref: '#/definitions/api.corpusImportTaskView'
+        "400":
+          description: 请求或参数错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "401":
+          description: 未登录
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "403":
+          description: 无权限
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "503":
+          description: 服务端错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+    post:
+      consumes:
+        - multipart/form-data
+      produces:
+        - application/json
+      tags:
+        - 语料 文档导入
+      summary: "上传 CSV 创建导入任务 \U0001F511"
+      parameters:
+        - type: string
+          description: 登录票据凭证
+          name: token
+          in: header
+          required: true
+        - type: file
+          description: CSV 文件（title,heading,content，UTF-8）
+          name: file
+          in: formData
+          required: true
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+              - $ref: '#/definitions/api.Done'
+              - type: object
+                properties:
+                  result:
+                    $ref: '#/definitions/api.corpusImportTaskView'
+        "400":
+          description: 请求或参数错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "401":
+          description: 未登录
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "403":
+          description: 无权限
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "413":
+          description: 文件过大
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "503":
+          description: 服务端错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+  /api/corpus/imports/{id}:
+    get:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - 语料 文档导入
+      summary: "获取导入任务详情 \U0001F511"
+      parameters:
+        - type: string
+          description: 登录票据凭证
+          name: token
+          in: header
+          required: true
+        - type: string
+          description: 任务ID
+          name: id
+          in: path
+          required: true
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+              - $ref: '#/definitions/api.Done'
+              - type: object
+                properties:
+                  result:
+                    $ref: '#/definitions/api.corpusImportTaskView'
+        "400":
+          description: 请求或参数错误
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "401":
+          description: 未登录
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "403":
+          description: 无权限
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "404":
+          description: 目标未找到
+          schema:
+            $ref: '#/definitions/api.Failure'
+        "503":
+          description: 服务端错误
+          schema:
+            $ref: '#/definitions/api.Failure'
   /api/history/{cid}:
     get:
       consumes:
@@ -2268,6 +2729,35 @@ definitions:
         type: array
         items:
           type: string
+  api.corpusImportTaskView:
+    type: object
+    properties:
+      createdAt:
+        type: string
+      errors:
+        type: array
+        items:
+          $ref: '#/definitions/corpusImportFailure'
+      failed:
+        type: integer
+      filename:
+        type: string
+      finishedAt:
+        type: string
+      id:
+        type: string
+      skipped:
+        type: integer
+      startedAt:
+        type: string
+      status:
+        $ref: '#/definitions/corpus.ImportTaskStatus'
+      success:
+        type: integer
+      total:
+        type: integer
+      updatedAt:
+        type: string
   api.respSession:
     type: object
     properties:
@@ -2276,6 +2766,9 @@ definitions:
         properties:
           auth:
             description: need auth
+            type: boolean
+          keeper:
+            description: user is keeper
             type: boolean
           model:
             description: for chatgpt-web
@@ -2617,6 +3110,95 @@ definitions:
         allOf:
           - $ref: '#/definitions/Meta'
         x-order: '|'
+  corpus.ImportTaskStatus:
+    type: integer
+    format: int32
+    enum:
+      - 1
+      - 2
+      - 3
+      - 4
+    x-enum-comments:
+      ImportTaskStatusFailed: 4 已失败
+      ImportTaskStatusPending: 1 排队中
+      ImportTaskStatusProcessing: 2 处理中
+      ImportTaskStatusSucceeded: 3 已完成
+    x-enum-descriptions:
+      - 1 排队中
+      - 2 处理中
+      - 3 已完成
+      - 4 已失败
+    x-enum-varnames:
+      - ImportTaskStatusPending
+      - ImportTaskStatusProcessing
+      - ImportTaskStatusSucceeded
+      - ImportTaskStatusFailed
+  corpusDocument:
+    type: object
+    properties:
+      createdAt:
+        description: 创建时间
+        type: string
+        x-order: ""
+      id:
+        description: 主键
+        type: string
+        x-order: '!'
+      updatedAt:
+        description: 变更时间
+        type: string
+        x-order: .
+      title:
+        description: 主标题 名称
+        type: string
+        x-order: A
+      heading:
+        description: 小节标题 属性 类别
+        type: string
+        x-order: B
+      content:
+        description: 内容 值
+        type: string
+        x-order: C
+      creatorID:
+        description: 创建者ID
+        type: string
+        x-order: _
+      meta:
+        description: Meta 元信息
+        allOf:
+          - $ref: '#/definitions/Meta'
+        x-order: '|'
+  corpusDocumentSet:
+    type: object
+    properties:
+      title:
+        description: 主标题 名称
+        type: string
+        x-order: A
+      heading:
+        description: 小节标题 属性 类别
+        type: string
+        x-order: B
+      content:
+        description: 内容 值
+        type: string
+        x-order: C
+  corpusImportFailure:
+    type: object
+    properties:
+      line:
+        description: 行号（表头为第 1 行，数据从第 2 行起）
+        type: integer
+        x-order: A
+      title:
+        description: 该行标题
+        type: string
+        x-order: B
+      reason:
+        description: 失败原因
+        type: string
+        x-order: C
   mcps.ToolDescriptor:
     type: object
     properties:
@@ -2893,12 +3475,12 @@ definitions:
       kind:
         description: |-
           文件类型
-           * `binary` - 二进制
            * `text` - 文本
+           * `binary` - 二进制
         type: string
         enum:
-          - binary
           - text
+          - binary
         x-order: E
       size:
         description: 字节数

--- a/main.go
+++ b/main.go
@@ -419,11 +419,16 @@ func webRun(cc *cli.Context) error {
 	})
 
 	ctx := context.Background()
+	wctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go stores.NewImportWorker(stores.Sgt().Corpus()).Run(wctx)
+
 	go func() {
 		quit := make(chan os.Signal, 2)
 		signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 		<-quit
 		logger().Info("shuting down server...")
+		cancel()
 		if err := srv.Stop(ctx); err != nil {
 			logger().Infow("server shutdown:", "err", err)
 		}

--- a/pkg/models/corpus/corpus_gen.go
+++ b/pkg/models/corpus/corpus_gen.go
@@ -3,9 +3,58 @@
 package corpus
 
 import (
+	"fmt"
+	"time"
+
 	comm "github.com/cupogo/andvari/models/comm"
 	oid "github.com/cupogo/andvari/models/oid"
 )
+
+// 导入任务状态
+type ImportTaskStatus int8
+
+const (
+	ImportTaskStatusPending    ImportTaskStatus = 1 + iota //  1 排队中
+	ImportTaskStatusProcessing                             //  2 处理中
+	ImportTaskStatusSucceeded                              //  3 已完成
+	ImportTaskStatusFailed                                 //  4 已失败
+)
+
+func (z *ImportTaskStatus) Decode(s string) error {
+	switch s {
+	case "1", "pending", "Pending":
+		*z = ImportTaskStatusPending
+	case "2", "processing", "Processing":
+		*z = ImportTaskStatusProcessing
+	case "3", "succeeded", "Succeeded":
+		*z = ImportTaskStatusSucceeded
+	case "4", "failed", "Failed":
+		*z = ImportTaskStatusFailed
+	default:
+		return fmt.Errorf("invalid importTaskStatus: %q", s)
+	}
+	return nil
+}
+func (z *ImportTaskStatus) UnmarshalText(b []byte) error {
+	return z.Decode(string(b))
+}
+func (z ImportTaskStatus) String() string {
+	switch z {
+	case ImportTaskStatusPending:
+		return "pending"
+	case ImportTaskStatusProcessing:
+		return "processing"
+	case ImportTaskStatusSucceeded:
+		return "succeeded"
+	case ImportTaskStatusFailed:
+		return "failed"
+	default:
+		return fmt.Sprintf("importTaskStatus %d", int8(z))
+	}
+}
+func (z ImportTaskStatus) MarshalText() ([]byte, error) {
+	return []byte(z.String()), nil
+}
 
 // consts of Document 文档
 const (
@@ -297,3 +346,179 @@ func (in *ChatLogSet) MetaAddKVs(args ...any) *ChatLogSet {
 	in.MetaDiff = comm.MetaDiffAddKVs(in.MetaDiff, args...)
 	return in
 }
+
+// consts of ImportTask 文档导入任务
+const (
+	ImportTaskTable = "corpus_import"
+	ImportTaskAlias = "ci"
+	ImportTaskLabel = "importTask"
+	ImportTaskTypID = "corpusImportTask"
+)
+
+// ImportTask 文档导入任务
+type ImportTask struct {
+	comm.BaseModel `bun:"table:corpus_import,alias:ci" json:"-"`
+
+	comm.DefaultModel
+
+	ImportTaskBasic
+
+	comm.MetaField
+} // @name corpusImportTask
+
+type ImportTaskBasic struct {
+	// 原始文件名
+	Filename string `bun:",notnull,type:varchar(255)" extensions:"x-order=A" form:"filename" json:"filename" pg:",notnull,type:varchar(255)"`
+	// 任务状态
+	//  * `pending` - 排队中
+	//  * `processing` - 处理中
+	//  * `succeeded` - 已完成
+	//  * `failed` - 已失败
+	Status ImportTaskStatus `bun:",notnull,type:smallint,default:1" enums:"pending,processing,succeeded,failed" extensions:"x-order=B" form:"status" json:"status" pg:",notnull,type:smallint,default:1" swaggertype:"string"`
+	// 原始 CSV 内容（worker 读取处理）
+	Data string `bun:",notnull,type:text" extensions:"x-order=C" form:"data" json:"data,omitempty" pg:",notnull,type:text"`
+	// 总数据行数
+	Total int `bun:",notnull,default:0" extensions:"x-order=D" form:"total" json:"total" pg:",notnull,default:0"`
+	// 成功行数
+	Success int `bun:",notnull,default:0" extensions:"x-order=E" form:"success" json:"success" pg:",notnull,default:0"`
+	// 失败行数
+	Failed int `bun:",notnull,default:0" extensions:"x-order=F" form:"failed" json:"failed" pg:",notnull,default:0"`
+	// 跳过行数（重复行）
+	Skipped int `bun:",notnull,default:0" extensions:"x-order=G" form:"skipped" json:"skipped" pg:",notnull,default:0"`
+	// 失败明细
+	Errors []ImportFailure `bun:",notnull,type:jsonb,default:'[]'" extensions:"x-order=H" json:"errors,omitempty" pg:",notnull,type:jsonb,default:'[]'"`
+	// 开始处理时间
+	StartedAt *time.Time `bun:"started_at,type:timestamptz" extensions:"x-order=I" json:"startedAt,omitempty" pg:"started_at,type:timestamptz"`
+	// 完成时间
+	FinishedAt *time.Time `bun:"finished_at,type:timestamptz" extensions:"x-order=J" json:"finishedAt,omitempty" pg:"finished_at,type:timestamptz"`
+	// for meta update
+	MetaDiff *comm.MetaDiff `bson:"-" bun:"-" json:"metaUp,omitempty" pg:"-" swaggerignore:"true"`
+} // @name corpusImportTaskBasic
+
+type ImportTasks []ImportTask
+
+// Creating function call to it's inner fields defined hooks
+func (z *ImportTask) Creating() error {
+	if z.IsZeroID() {
+		z.SetID(oid.NewID(oid.OtTask))
+	}
+
+	return z.DefaultModel.Creating()
+}
+func NewImportTaskWithBasic(in ImportTaskBasic) *ImportTask {
+	obj := &ImportTask{
+		ImportTaskBasic: in,
+	}
+	_ = obj.MetaUp(in.MetaDiff)
+	return obj
+}
+func NewImportTaskWithID(id any) *ImportTask {
+	obj := new(ImportTask)
+	_ = obj.SetID(id)
+	return obj
+}
+func (_ *ImportTask) IdentityLabel() string { return ImportTaskLabel }
+func (_ *ImportTask) IdentityModel() string { return ImportTaskTypID }
+func (_ *ImportTask) IdentityTable() string { return ImportTaskTable }
+func (_ *ImportTask) IdentityAlias() string { return ImportTaskAlias }
+
+type ImportTaskSet struct {
+	// 原始文件名
+	Filename *string `extensions:"x-order=A" json:"filename"`
+	// 任务状态
+	//  * `pending` - 排队中
+	//  * `processing` - 处理中
+	//  * `succeeded` - 已完成
+	//  * `failed` - 已失败
+	Status *ImportTaskStatus `enums:"pending,processing,succeeded,failed" extensions:"x-order=B" json:"status" swaggertype:"string"`
+	// 原始 CSV 内容（worker 读取处理）
+	Data *string `extensions:"x-order=C" form:"data" json:"data,omitempty"`
+	// 总数据行数
+	Total *int `extensions:"x-order=D" json:"total"`
+	// 成功行数
+	Success *int `extensions:"x-order=E" json:"success"`
+	// 失败行数
+	Failed *int `extensions:"x-order=F" json:"failed"`
+	// 跳过行数（重复行）
+	Skipped *int `extensions:"x-order=G" json:"skipped"`
+	// 失败明细
+	Errors *[]ImportFailure `extensions:"x-order=H" json:"errors,omitempty"`
+	// 开始处理时间
+	StartedAt *time.Time `extensions:"x-order=I" json:"startedAt,omitempty"`
+	// 完成时间
+	FinishedAt *time.Time `extensions:"x-order=J" json:"finishedAt,omitempty"`
+	// for meta update
+	MetaDiff *comm.MetaDiff `json:"metaUp,omitempty" swaggerignore:"true"`
+} // @name corpusImportTaskSet
+
+func (z *ImportTask) SetWith(o ImportTaskSet) {
+	if o.Filename != nil && z.Filename != *o.Filename {
+		z.LogChangeValue("filename", z.Filename, o.Filename)
+		z.Filename = *o.Filename
+	}
+	if o.Status != nil && z.Status != *o.Status {
+		z.LogChangeValue("status", z.Status, o.Status)
+		z.Status = *o.Status
+	}
+	if o.Data != nil && z.Data != *o.Data {
+		z.LogChangeValue("data", z.Data, o.Data)
+		z.Data = *o.Data
+	}
+	if o.Total != nil && z.Total != *o.Total {
+		z.LogChangeValue("total", z.Total, o.Total)
+		z.Total = *o.Total
+	}
+	if o.Success != nil && z.Success != *o.Success {
+		z.LogChangeValue("success", z.Success, o.Success)
+		z.Success = *o.Success
+	}
+	if o.Failed != nil && z.Failed != *o.Failed {
+		z.LogChangeValue("failed", z.Failed, o.Failed)
+		z.Failed = *o.Failed
+	}
+	if o.Skipped != nil && z.Skipped != *o.Skipped {
+		z.LogChangeValue("skipped", z.Skipped, o.Skipped)
+		z.Skipped = *o.Skipped
+	}
+	if o.Errors != nil {
+		z.LogChangeValue("errors", z.Errors, o.Errors)
+		z.Errors = *o.Errors
+	}
+	if o.StartedAt != nil {
+		z.LogChangeValue("started_at", z.StartedAt, o.StartedAt)
+		z.StartedAt = o.StartedAt
+	}
+	if o.FinishedAt != nil {
+		z.LogChangeValue("finished_at", z.FinishedAt, o.FinishedAt)
+		z.FinishedAt = o.FinishedAt
+	}
+	if o.MetaDiff != nil && z.MetaUp(o.MetaDiff) {
+		z.SetChange("meta")
+	}
+}
+func (in *ImportTaskBasic) MetaAddKVs(args ...any) *ImportTaskBasic {
+	in.MetaDiff = comm.MetaDiffAddKVs(in.MetaDiff, args...)
+	return in
+}
+func (in *ImportTaskSet) MetaAddKVs(args ...any) *ImportTaskSet {
+	in.MetaDiff = comm.MetaDiffAddKVs(in.MetaDiff, args...)
+	return in
+}
+
+// consts of ImportFailure 导入失败明细
+const (
+	ImportFailureLabel = "importFailure"
+	ImportFailureTypID = "corpusImportFailure"
+)
+
+// ImportFailure 导入失败明细
+type ImportFailure struct {
+	// 行号（表头为第 1 行，数据从第 2 行起）
+	Line int `extensions:"x-order=A" form:"line" json:"line"`
+	// 该行标题
+	Title string `extensions:"x-order=B" form:"title" json:"title"`
+	// 失败原因
+	Reason string `extensions:"x-order=C" form:"reason" json:"reason"`
+} // @name corpusImportFailure
+
+type ImportFailures []ImportFailure

--- a/pkg/models/corpus/import_task_test.go
+++ b/pkg/models/corpus/import_task_test.go
@@ -1,0 +1,66 @@
+package corpus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImportTaskStatusValues(t *testing.T) {
+	assert.Equal(t, ImportTaskStatus(1), ImportTaskStatusPending)
+	assert.Equal(t, ImportTaskStatus(2), ImportTaskStatusProcessing)
+	assert.Equal(t, ImportTaskStatus(3), ImportTaskStatusSucceeded)
+	assert.Equal(t, ImportTaskStatus(4), ImportTaskStatusFailed)
+}
+
+func TestImportTaskStatusString(t *testing.T) {
+	assert.Equal(t, "pending", ImportTaskStatusPending.String())
+	assert.Equal(t, "processing", ImportTaskStatusProcessing.String())
+	assert.Equal(t, "succeeded", ImportTaskStatusSucceeded.String())
+	assert.Equal(t, "failed", ImportTaskStatusFailed.String())
+}
+
+func TestImportTaskStatusDecode(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want ImportTaskStatus
+	}{
+		{"1", ImportTaskStatusPending},
+		{"pending", ImportTaskStatusPending},
+		{"Pending", ImportTaskStatusPending},
+		{"2", ImportTaskStatusProcessing},
+		{"processing", ImportTaskStatusProcessing},
+		{"Processing", ImportTaskStatusProcessing},
+		{"3", ImportTaskStatusSucceeded},
+		{"succeeded", ImportTaskStatusSucceeded},
+		{"Succeeded", ImportTaskStatusSucceeded},
+		{"4", ImportTaskStatusFailed},
+		{"failed", ImportTaskStatusFailed},
+		{"Failed", ImportTaskStatusFailed},
+	} {
+		var got ImportTaskStatus
+		assert.NoError(t, got.Decode(tc.in), "decode %q", tc.in)
+		assert.Equal(t, tc.want, got)
+	}
+
+	var got ImportTaskStatus
+	assert.Error(t, got.Decode("unknown"))
+	assert.Error(t, got.Decode(""))
+	assert.Error(t, got.Decode("5"))
+}
+
+func TestImportTaskStatusTextRoundTrip(t *testing.T) {
+	for _, s := range []ImportTaskStatus{
+		ImportTaskStatusPending,
+		ImportTaskStatusProcessing,
+		ImportTaskStatusSucceeded,
+		ImportTaskStatusFailed,
+	} {
+		b, err := s.MarshalText()
+		assert.NoError(t, err)
+
+		var got ImportTaskStatus
+		assert.NoError(t, got.UnmarshalText(b))
+		assert.Equal(t, s, got)
+	}
+}

--- a/pkg/services/stores/corpus_gen.go
+++ b/pkg/services/stores/corpus_gen.go
@@ -13,9 +13,12 @@ import (
 // type DocMatches = corpus.DocMatches
 // type CobDocVector = corpus.DocVector
 // type CobDocument = corpus.Document
+// type ImportFailure = corpus.ImportFailure
+// type ImportFailures = corpus.ImportFailures
+// type CobImportTask = corpus.ImportTask
 
 func init() {
-	RegisterModel((*corpus.Document)(nil), (*corpus.DocVector)(nil), (*corpus.ChatLog)(nil))
+	RegisterModel((*corpus.Document)(nil), (*corpus.DocVector)(nil), (*corpus.ChatLog)(nil), (*corpus.ImportTask)(nil))
 }
 
 type CorpuStore interface {
@@ -35,6 +38,12 @@ type CorpuStore interface {
 	GetChatLog(ctx context.Context, id string) (obj *corpus.ChatLog, err error)
 	ListChatLog(ctx context.Context, spec *ChatLogSpec) (data corpus.ChatLogs, total int, err error)
 	DeleteChatLog(ctx context.Context, id string) error
+
+	ListImportTask(ctx context.Context, spec *CobImportTaskSpec) (data corpus.ImportTasks, total int, err error)
+	GetImportTask(ctx context.Context, id string) (obj *corpus.ImportTask, err error)
+	CreateImportTask(ctx context.Context, in corpus.ImportTaskBasic) (obj *corpus.ImportTask, err error)
+	UpdateImportTask(ctx context.Context, id string, in corpus.ImportTaskSet) error
+	DeleteImportTask(ctx context.Context, id string) error
 }
 
 type CobDocumentSpec struct {
@@ -79,6 +88,36 @@ func (spec *ChatLogSpec) Sift(q *ormQuery) *ormQuery {
 	q, _ = siftOID(q, "csid", spec.ChatID, false)
 
 	return q
+}
+
+type CobImportTaskSpec struct {
+	PageSpec
+	ModelSpec
+
+	// 原始文件名
+	Filename string `extensions:"x-order=A" form:"filename" json:"filename"`
+	// 任务状态
+	//  * `pending` - 排队中
+	//  * `processing` - 处理中
+	//  * `succeeded` - 已完成
+	//  * `failed` - 已失败
+	Status corpus.ImportTaskStatus `extensions:"x-order=B" form:"status" json:"status" swaggertype:"string"`
+}
+
+func (spec *CobImportTaskSpec) Sift(q *ormQuery) *ormQuery {
+	q = spec.ModelSpec.Sift(q)
+	q, _ = siftMatch(q, "filename", spec.Filename, false)
+	q, _ = siftEqual(q, "status", spec.Status, false)
+
+	return q
+}
+func (spec *CobImportTaskSpec) CanSort(k string) bool {
+	switch k {
+	case "filename", "status":
+		return true
+	default:
+		return spec.ModelSpec.CanSort(k)
+	}
 }
 
 type corpuStore struct {
@@ -163,5 +202,36 @@ func (s *corpuStore) ListChatLog(ctx context.Context, spec *ChatLogSpec) (data c
 }
 func (s *corpuStore) DeleteChatLog(ctx context.Context, id string) error {
 	obj := new(corpus.ChatLog)
+	return s.w.db.DeleteModel(ctx, obj, id)
+}
+
+func (s *corpuStore) ListImportTask(ctx context.Context, spec *CobImportTaskSpec) (data corpus.ImportTasks, total int, err error) {
+	total, err = s.w.db.ListModel(ctx, spec, &data)
+	return
+}
+func (s *corpuStore) GetImportTask(ctx context.Context, id string) (obj *corpus.ImportTask, err error) {
+	obj = new(corpus.ImportTask)
+	err = dbGetWithPKID(ctx, s.w.db, obj, id)
+
+	return
+}
+func (s *corpuStore) CreateImportTask(ctx context.Context, in corpus.ImportTaskBasic) (obj *corpus.ImportTask, err error) {
+	obj = corpus.NewImportTaskWithBasic(in)
+	dbMetaUp(ctx, s.w.db, obj)
+	err = dbInsert(ctx, s.w.db, obj)
+	return
+}
+func (s *corpuStore) UpdateImportTask(ctx context.Context, id string, in corpus.ImportTaskSet) error {
+	exist := new(corpus.ImportTask)
+	if err := dbGetWithPKID(ctx, s.w.db, exist, id); err != nil {
+		return err
+	}
+	exist.SetIsUpdate(true)
+	exist.SetWith(in)
+	dbMetaUp(ctx, s.w.db, exist)
+	return dbUpdate(ctx, s.w.db, exist)
+}
+func (s *corpuStore) DeleteImportTask(ctx context.Context, id string) error {
+	obj := new(corpus.ImportTask)
 	return s.w.db.DeleteModel(ctx, obj, id)
 }

--- a/pkg/services/stores/corpus_x.go
+++ b/pkg/services/stores/corpus_x.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/pmezard/go-difflib/difflib"
 	"github.com/spf13/cast"
@@ -19,6 +20,9 @@ import (
 
 const (
 	Separator = "\n* "
+
+	maxImportErrors    = 500
+	maxImportReasonLen = 200
 )
 
 var (
@@ -56,8 +60,8 @@ type ExportArg struct {
 	Format string // csv,jsonl
 }
 
-// validHead validates if CSV header is valid
-func validHead(rec []string) bool {
+// ValidHead validates if CSV header is valid
+func ValidHead(rec []string) bool {
 	if len(rec) < len(qaHeads) {
 		return false
 	}
@@ -78,6 +82,9 @@ type CorpuStoreX interface {
 	SyncEmbeddingDocments(ctx context.Context, spec *CobDocumentSpec) error
 	MatchDocments(ctx context.Context, ms MatchSpec) (data corpus.Documents, err error)
 	MatchVectorWith(ctx context.Context, vec corpus.Vector, threshold float32, limit int) (data corpus.DocMatches, err error)
+	ClaimImportTask(ctx context.Context) (obj *corpus.ImportTask, err error)
+	ProcessImportTask(ctx context.Context, task *corpus.ImportTask) error
+	RecoverImportTasks(ctx context.Context) (int, error)
 	InvokerForSearch() mcps.Invoker
 	InvokerForCreate() mcps.Invoker
 }
@@ -90,7 +97,7 @@ func (s *corpuStore) ImportDocs(ctx context.Context, r io.Reader, lw io.Writer) 
 		logger().Infow("read fail", "err", err)
 		return err
 	}
-	if !validHead(rec) {
+	if !ValidHead(rec) {
 		return fmt.Errorf("invalid csv head: %+v", rec)
 	}
 
@@ -121,6 +128,161 @@ func (s *corpuStore) ImportDocs(ctx context.Context, r io.Reader, lw io.Writer) 
 		}
 		valid++
 	}
+}
+
+// ClaimImportTask 原子认领最早的 pending 导入任务，无任务时返回 ErrNotFound
+func (s *corpuStore) ClaimImportTask(ctx context.Context) (obj *corpus.ImportTask, err error) {
+	obj = new(corpus.ImportTask)
+	err = s.w.db.NewUpdate().
+		Model(obj).
+		Set("status = ?", corpus.ImportTaskStatusProcessing).
+		Set("started_at = ?", time.Now()).
+		Where("status = ?", corpus.ImportTaskStatusPending).
+		Where("id = (SELECT id FROM ? WHERE status = ? ORDER BY created, id LIMIT 1 FOR UPDATE SKIP LOCKED)",
+			pgIdent(corpus.ImportTaskTable), corpus.ImportTaskStatusPending).
+		Returning("*").
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		logger().Infow("claim import task fail", "err", err)
+		return nil, err
+	}
+	return obj, nil
+}
+
+// ProcessImportTask 处理单个导入任务：解析 CSV、逐行查重/导入并写回计数、明细与状态
+func (s *corpuStore) ProcessImportTask(ctx context.Context, task *corpus.ImportTask) error {
+	rd := csv.NewReader(strings.NewReader(task.Data))
+	rd.FieldsPerRecord = -1
+
+	rec, err := rd.Read()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			// 空文件：正常结束，计数全 0
+			return s.finishImportTask(ctx, task, corpus.ImportTaskStatusSucceeded, 0, 0, 0, 0, nil)
+		}
+		return s.finishImportTask(ctx, task, corpus.ImportTaskStatusFailed, 0, 0, 0, 0, nil)
+	}
+	if !ValidHead(rec) {
+		logger().Infow("invalid import task head", "id", task.StringID())
+		return s.finishImportTask(ctx, task, corpus.ImportTaskStatusFailed, 0, 0, 0, 0, nil)
+	}
+
+	var (
+		total, success, failed, skipped int
+		errs                             []corpus.ImportFailure
+	)
+	for {
+		row, err := rd.Read()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			// CSV 中途解析错误 → 任务失败
+			logger().Infow("import task csv parse fail", "id", task.StringID(), "err", err)
+			return s.finishImportTask(ctx, task, corpus.ImportTaskStatusFailed, total, success, failed, skipped, errs)
+		}
+		line, _ := rd.FieldPos(0)
+		total++
+		if !validImportRow(row) {
+			failed++
+			errs = appendImportError(errs, corpus.ImportFailure{
+				Line:   line,
+				Title:  importRowTitle(row),
+				Reason: "数据无效",
+			})
+			continue
+		}
+
+		basic := corpus.DocumentBasic{
+			Title:   row[0],
+			Heading: row[1],
+			Content: replText.Replace(row[2]),
+		}
+		exist := new(corpus.Document)
+		err = dbGet(ctx, s.w.db, exist, "title = ? AND heading = ?", basic.Title, basic.Heading)
+		switch {
+		case err == nil:
+			skipped++
+			errs = appendImportError(errs, corpus.ImportFailure{
+				Line:   line,
+				Title:  basic.Title,
+				Reason: "重复文档: title+heading 已存在，跳过",
+			})
+		case errors.Is(err, ErrNotFound):
+			if _, cerr := s.CreateDocument(ctx, basic); cerr != nil {
+				failed++
+				errs = appendImportError(errs, corpus.ImportFailure{
+					Line:   line,
+					Title:  basic.Title,
+					Reason: cerr.Error(),
+				})
+			} else {
+				success++
+			}
+		default:
+			failed++
+			errs = appendImportError(errs, corpus.ImportFailure{
+				Line:   line,
+				Title:  basic.Title,
+				Reason: err.Error(),
+			})
+		}
+	}
+
+	return s.finishImportTask(ctx, task, corpus.ImportTaskStatusSucceeded, total, success, failed, skipped, errs)
+}
+
+// RecoverImportTasks 将遗留的 processing 任务重置为 pending，返回受影响数量
+func (s *corpuStore) RecoverImportTasks(ctx context.Context) (int, error) {
+	res, err := s.w.db.NewUpdate().
+		Model((*corpus.ImportTask)(nil)).
+		Set("status = ?", corpus.ImportTaskStatusPending).
+		Where("status = ?", corpus.ImportTaskStatusProcessing).
+		Exec(ctx)
+	if err != nil {
+		logger().Infow("recover import tasks fail", "err", err)
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
+func validImportRow(row []string) bool {
+	return len(row) >= 3 && len(row[0]) > 0 && len(row[1]) > 0 && len(row[2]) > 0
+}
+
+func importRowTitle(row []string) string {
+	if len(row) > 0 {
+		return row[0]
+	}
+	return ""
+}
+
+func appendImportError(errs []corpus.ImportFailure, f corpus.ImportFailure) []corpus.ImportFailure {
+	if r := []rune(f.Reason); len(r) > maxImportReasonLen {
+		f.Reason = string(r[:maxImportReasonLen])
+	}
+	if len(errs) >= maxImportErrors {
+		return errs
+	}
+	return append(errs, f)
+}
+
+func (s *corpuStore) finishImportTask(ctx context.Context, task *corpus.ImportTask,
+	status corpus.ImportTaskStatus, total, success, failed, skipped int, errs []corpus.ImportFailure) error {
+	now := time.Now()
+	return s.UpdateImportTask(ctx, task.StringID(), corpus.ImportTaskSet{
+		Status:     &status,
+		Total:      &total,
+		Success:    &success,
+		Failed:     &failed,
+		Skipped:    &skipped,
+		Errors:     &errs,
+		FinishedAt: &now,
+	})
 }
 
 // importLine imports a single line of document data

--- a/pkg/services/stores/import_task_test.go
+++ b/pkg/services/stores/import_task_test.go
@@ -1,0 +1,284 @@
+//go:build integration
+
+package stores
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/liut/morign/pkg/models/corpus"
+	"github.com/liut/morign/pkg/services/llm"
+)
+
+var importTaskSeq int
+
+func importTaskTitle(prefix string) string {
+	importTaskSeq++
+	return fmt.Sprintf("it-%s-%d-%d", prefix, os.Getpid(), importTaskSeq)
+}
+
+// runImportTask 创建 pending 任务并走完 claim → process → 回读
+func runImportTask(t *testing.T, data string) *corpus.ImportTask {
+	t.Helper()
+	ctx := context.Background()
+	sto := Sgt().Corpus()
+
+	obj, err := sto.CreateImportTask(ctx, corpus.ImportTaskBasic{
+		Filename: "test.csv",
+		Status:   corpus.ImportTaskStatusPending,
+		Data:     data,
+	})
+	require.NoError(t, err)
+
+	claimed, err := sto.ClaimImportTask(ctx)
+	require.NoError(t, err)
+	require.Equal(t, obj.StringID(), claimed.StringID())
+	assert.Equal(t, corpus.ImportTaskStatusProcessing, claimed.Status)
+	assert.NotNil(t, claimed.StartedAt)
+
+	require.NoError(t, sto.ProcessImportTask(ctx, claimed))
+
+	got, err := sto.GetImportTask(ctx, obj.StringID())
+	require.NoError(t, err)
+	return got
+}
+
+func assertImportCounts(t *testing.T, task *corpus.ImportTask, total, success, failed, skipped int) {
+	t.Helper()
+	assert.Equal(t, total, task.Total)
+	assert.Equal(t, success, task.Success)
+	assert.Equal(t, failed, task.Failed)
+	assert.Equal(t, skipped, task.Skipped)
+	assert.Equal(t, total, success+failed+skipped, "Total must equal Success+Failed+Skipped")
+}
+
+func getDocument(t *testing.T, title, heading string) *corpus.Document {
+	t.Helper()
+	doc := new(corpus.Document)
+	err := dbGet(context.Background(), Sgt().db, doc, "title = ? AND heading = ?", title, heading)
+	require.NoError(t, err)
+	return doc
+}
+
+func TestIntegration_ImportTaskSuccess(t *testing.T) {
+	title := importTaskTitle("ok")
+	data := "title,heading,content\n" +
+		title + ",a,hello a\n" +
+		title + ",b,hello b\n" +
+		title + ",c,hello c\n"
+
+	got := runImportTask(t, data)
+
+	assert.Equal(t, corpus.ImportTaskStatusSucceeded, got.Status)
+	assertImportCounts(t, got, 3, 3, 0, 0)
+	assert.NotNil(t, got.StartedAt)
+	assert.NotNil(t, got.FinishedAt)
+	assert.Empty(t, got.Errors)
+
+	for _, h := range []string{"a", "b", "c"} {
+		doc := getDocument(t, title, h)
+		dv := new(corpus.DocVector)
+		err := dbGetWithUnique(context.Background(), Sgt().db, dv, "doc_id", doc.ID)
+		assert.NoError(t, err, "vector missing for %s", h)
+	}
+}
+
+func TestIntegration_ImportTaskEmptyAndHeaderOnly(t *testing.T) {
+	for name, data := range map[string]string{
+		"empty":       "",
+		"header_only": "title,heading,content\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := runImportTask(t, data)
+			assert.Equal(t, corpus.ImportTaskStatusSucceeded, got.Status)
+			assertImportCounts(t, got, 0, 0, 0, 0)
+		})
+	}
+}
+
+func TestIntegration_ImportTaskDuplicateInFile(t *testing.T) {
+	title := importTaskTitle("dup")
+	data := "title,heading,content\n" +
+		title + ",h,first\n" +
+		title + ",h,second\n"
+
+	got := runImportTask(t, data)
+
+	assert.Equal(t, corpus.ImportTaskStatusSucceeded, got.Status)
+	assertImportCounts(t, got, 2, 1, 0, 1)
+	require.Len(t, got.Errors, 1)
+	assert.Equal(t, 3, got.Errors[0].Line)
+	assert.Contains(t, got.Errors[0].Reason, "重复")
+
+	doc := getDocument(t, title, "h")
+	assert.Equal(t, "first", doc.Content, "duplicate row must not overwrite existing document")
+}
+
+func TestIntegration_ImportTaskInvalidRows(t *testing.T) {
+	title := importTaskTitle("bad")
+	data := "title,heading,content\n" +
+		title + ",ok,hello\n" +
+		",,\n" +
+		"short\n"
+
+	got := runImportTask(t, data)
+
+	assert.Equal(t, corpus.ImportTaskStatusSucceeded, got.Status)
+	assertImportCounts(t, got, 3, 1, 2, 0)
+	require.Len(t, got.Errors, 2)
+	assert.Equal(t, "数据无效", got.Errors[0].Reason)
+	assert.Equal(t, "数据无效", got.Errors[1].Reason)
+	assert.Equal(t, 3, got.Errors[0].Line)
+	assert.Equal(t, 4, got.Errors[1].Line)
+}
+
+// failEmbeddingClient 对包含指定文本的 embedding 请求返回错误
+type failEmbeddingClient struct {
+	llm.Client
+	failFor string
+}
+
+func (m *failEmbeddingClient) Embedding(ctx context.Context, texts []string) ([]float64, error) {
+	for _, text := range texts {
+		if strings.Contains(text, m.failFor) {
+			return nil, errors.New(m.failFor)
+		}
+	}
+	return m.Client.Embedding(ctx, texts)
+}
+
+func TestIntegration_ImportTaskEmbeddingFailure(t *testing.T) {
+	old := llmEm
+	defer func() { llmEm = old }()
+	bad := "emb-boom-heading"
+	llmEm = &failEmbeddingClient{Client: old, failFor: bad}
+
+	title := importTaskTitle("emb")
+	data := "title,heading,content\n" +
+		title + ",good1,hello\n" +
+		title + "," + bad + ",hello\n" +
+		title + ",good2,hello\n"
+
+	got := runImportTask(t, data)
+
+	assert.Equal(t, corpus.ImportTaskStatusSucceeded, got.Status)
+	assertImportCounts(t, got, 3, 2, 1, 0)
+	require.Len(t, got.Errors, 1)
+	assert.Equal(t, 3, got.Errors[0].Line)
+	assert.Contains(t, got.Errors[0].Reason, bad)
+}
+
+func TestIntegration_ImportTaskMalformedCSV(t *testing.T) {
+	data := "title,heading,content\n" +
+		"ok,h,\"unclosed\n"
+
+	got := runImportTask(t, data)
+
+	assert.Equal(t, corpus.ImportTaskStatusFailed, got.Status)
+	assertImportCounts(t, got, 0, 0, 0, 0)
+	assert.NotNil(t, got.FinishedAt)
+}
+
+func TestIntegration_ImportTaskErrorCap(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString("title,heading,content\n")
+	for i := 0; i < 510; i++ {
+		sb.WriteString(",,invalid-row\n")
+	}
+
+	got := runImportTask(t, sb.String())
+
+	assert.Equal(t, corpus.ImportTaskStatusSucceeded, got.Status)
+	assertImportCounts(t, got, 510, 0, 510, 0)
+	require.Len(t, got.Errors, maxImportErrors)
+}
+
+func TestIntegration_ImportTaskReasonTruncation(t *testing.T) {
+	old := llmEm
+	defer func() { llmEm = old }()
+	bad := strings.Repeat("x", 300)
+	llmEm = &failEmbeddingClient{Client: old, failFor: bad}
+
+	title := importTaskTitle("trunc")
+	data := "title,heading,content\n" +
+		title + "," + bad + ",hello\n"
+
+	got := runImportTask(t, data)
+
+	assert.Equal(t, corpus.ImportTaskStatusSucceeded, got.Status)
+	assertImportCounts(t, got, 1, 0, 1, 0)
+	require.Len(t, got.Errors, 1)
+	assert.Len(t, []rune(got.Errors[0].Reason), maxImportReasonLen)
+}
+
+func TestIntegration_ImportTaskSkipExisting(t *testing.T) {
+	ctx := context.Background()
+	title := importTaskTitle("exist")
+
+	_, err := Sgt().Corpus().CreateDocument(ctx, corpus.DocumentBasic{
+		Title:   title,
+		Heading: "h",
+		Content: "original",
+	})
+	require.NoError(t, err)
+
+	data := "title,heading,content\n" +
+		title + ",h,updated\n"
+	got := runImportTask(t, data)
+
+	assert.Equal(t, corpus.ImportTaskStatusSucceeded, got.Status)
+	assertImportCounts(t, got, 1, 0, 0, 1)
+	require.Len(t, got.Errors, 1)
+	assert.Contains(t, got.Errors[0].Reason, "重复")
+
+	doc := getDocument(t, title, "h")
+	assert.Equal(t, "original", doc.Content, "existing document must not be overwritten")
+}
+
+func TestIntegration_ImportTaskRecover(t *testing.T) {
+	ctx := context.Background()
+	sto := Sgt().Corpus()
+
+	o1, err := sto.CreateImportTask(ctx, corpus.ImportTaskBasic{
+		Filename: "a.csv",
+		Status:   corpus.ImportTaskStatusPending,
+		Data:     "title,heading,content\n",
+	})
+	require.NoError(t, err)
+	o2, err := sto.CreateImportTask(ctx, corpus.ImportTaskBasic{
+		Filename: "b.csv",
+		Status:   corpus.ImportTaskStatusPending,
+		Data:     "title,heading,content\n",
+	})
+	require.NoError(t, err)
+	defer func() {
+		_ = sto.DeleteImportTask(ctx, o1.StringID())
+		_ = sto.DeleteImportTask(ctx, o2.StringID())
+	}()
+
+	claimed, err := sto.ClaimImportTask(ctx)
+	require.NoError(t, err)
+	require.Equal(t, o1.StringID(), claimed.StringID())
+
+	n, err := sto.RecoverImportTasks(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+
+	got1, err := sto.GetImportTask(ctx, o1.StringID())
+	require.NoError(t, err)
+	got2, err := sto.GetImportTask(ctx, o2.StringID())
+	require.NoError(t, err)
+	assert.Equal(t, corpus.ImportTaskStatusPending, got1.Status)
+	assert.Equal(t, corpus.ImportTaskStatusPending, got2.Status)
+
+	reclaimed, err := sto.ClaimImportTask(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, o1.StringID(), reclaimed.StringID())
+}

--- a/pkg/services/stores/import_worker.go
+++ b/pkg/services/stores/import_worker.go
@@ -1,0 +1,68 @@
+package stores
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/liut/morign/pkg/models/corpus"
+)
+
+const importWorkerPollInterval = time.Second
+
+// ImportTaskProcessor 是导入 worker 依赖的最小接口
+type ImportTaskProcessor interface {
+	RecoverImportTasks(ctx context.Context) (int, error)
+	ClaimImportTask(ctx context.Context) (*corpus.ImportTask, error)
+	ProcessImportTask(ctx context.Context, task *corpus.ImportTask) error
+}
+
+// ImportWorker 进程内串行消费导入任务
+type ImportWorker struct {
+	sto      ImportTaskProcessor
+	interval time.Duration
+}
+
+func NewImportWorker(sto ImportTaskProcessor) *ImportWorker {
+	return &ImportWorker{sto: sto, interval: importWorkerPollInterval}
+}
+
+// Run 阻塞执行：先恢复遗留任务，再循环认领/处理，ctx 取消时退出
+func (w *ImportWorker) Run(ctx context.Context) {
+	n, err := w.sto.RecoverImportTasks(ctx)
+	if err != nil {
+		logger().Warnw("recover import tasks fail", "err", err)
+	} else if n > 0 {
+		logger().Infow("recovered import tasks", "n", n)
+	}
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		task, err := w.sto.ClaimImportTask(ctx)
+		if err != nil {
+			if !errors.Is(err, ErrNotFound) {
+				logger().Infow("claim import task fail", "err", err)
+			}
+			if !waitOrDone(ctx, w.interval) {
+				return
+			}
+			continue
+		}
+		if err := w.sto.ProcessImportTask(ctx, task); err != nil {
+			logger().Infow("process import task fail", "id", task.StringID(), "err", err)
+		}
+	}
+}
+
+func waitOrDone(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}

--- a/pkg/services/stores/import_worker_test.go
+++ b/pkg/services/stores/import_worker_test.go
@@ -1,0 +1,155 @@
+package stores
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/liut/morign/pkg/models/corpus"
+)
+
+func importTestTask(id string) *corpus.ImportTask {
+	obj := new(corpus.ImportTask)
+	obj.Data = id
+	return obj
+}
+
+type fakeTaskProcessor struct {
+	mu         sync.Mutex
+	queue      []*corpus.ImportTask
+	processErr error
+	recoverN   int
+	seq        []string
+}
+
+func (f *fakeTaskProcessor) RecoverImportTasks(ctx context.Context) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.seq = append(f.seq, "recover")
+	return f.recoverN, nil
+}
+
+func (f *fakeTaskProcessor) ClaimImportTask(ctx context.Context) (*corpus.ImportTask, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.queue) == 0 {
+		return nil, ErrNotFound
+	}
+	task := f.queue[0]
+	f.queue = f.queue[1:]
+	f.seq = append(f.seq, "claim:"+task.Data)
+	return task, nil
+}
+
+func (f *fakeTaskProcessor) ProcessImportTask(ctx context.Context, task *corpus.ImportTask) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.seq = append(f.seq, "process:"+task.Data)
+	return f.processErr
+}
+
+func (f *fakeTaskProcessor) snapshot() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.seq...)
+}
+
+func runWorker(t *testing.T, fake *fakeTaskProcessor) (context.CancelFunc, <-chan struct{}) {
+	t.Helper()
+	w := NewImportWorker(fake)
+	w.interval = time.Millisecond
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		w.Run(ctx)
+		close(done)
+	}()
+	return cancel, done
+}
+
+func eventuallySeq(t *testing.T, fake *fakeTaskProcessor, want []string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		got := fake.snapshot()
+		if len(got) != len(want) {
+			return false
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				return false
+			}
+		}
+		return true
+	}, 3*time.Second, 10*time.Millisecond)
+}
+
+func TestImportWorker_ProcessesTasksSerially(t *testing.T) {
+	fake := &fakeTaskProcessor{queue: []*corpus.ImportTask{importTestTask("t1"), importTestTask("t2")}}
+	cancel, done := runWorker(t, fake)
+	defer func() { cancel(); <-done }()
+
+	eventuallySeq(t, fake, []string{"recover", "claim:t1", "process:t1", "claim:t2", "process:t2"})
+}
+
+func TestImportWorker_WaitsForNewTask(t *testing.T) {
+	fake := &fakeTaskProcessor{}
+	cancel, done := runWorker(t, fake)
+	defer func() { cancel(); <-done }()
+
+	require.Eventually(t, func() bool {
+		return len(fake.snapshot()) > 0
+	}, 3*time.Second, 10*time.Millisecond)
+
+	fake.mu.Lock()
+	fake.queue = append(fake.queue, importTestTask("later"))
+	fake.mu.Unlock()
+
+	eventuallySeq(t, fake, []string{"recover", "claim:later", "process:later"})
+}
+
+func TestImportWorker_RecoversBeforeClaim(t *testing.T) {
+	fake := &fakeTaskProcessor{
+		queue:    []*corpus.ImportTask{importTestTask("t1")},
+		recoverN: 2,
+	}
+	cancel, done := runWorker(t, fake)
+	defer func() { cancel(); <-done }()
+
+	eventuallySeq(t, fake, []string{"recover", "claim:t1", "process:t1"})
+	assert.Equal(t, 2, fake.recoverN)
+}
+
+func TestImportWorker_ProcessErrorContinues(t *testing.T) {
+	fake := &fakeTaskProcessor{
+		queue:      []*corpus.ImportTask{importTestTask("t1"), importTestTask("t2")},
+		processErr: errors.New("boom"),
+	}
+	cancel, done := runWorker(t, fake)
+	defer func() { cancel(); <-done }()
+
+	eventuallySeq(t, fake, []string{"recover", "claim:t1", "process:t1", "claim:t2", "process:t2"})
+}
+
+func TestImportWorker_CancelExits(t *testing.T) {
+	fake := &fakeTaskProcessor{}
+	w := NewImportWorker(fake)
+	w.interval = time.Hour
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		w.Run(ctx)
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("worker did not exit after cancel")
+	}
+}

--- a/pkg/services/stores/wrap.go
+++ b/pkg/services/stores/wrap.go
@@ -37,6 +37,7 @@ var (
 	ErrNotFound  = pgx.ErrNotFound
 	ErrEmptyKey  = pgx.ErrEmptyKey
 	ErrDuplicate = pgx.ErrDuplicate
+	ErrInvalidID = pgx.ErrInvalidID
 
 	dbGet           = pgx.Get
 	dbFirst         = pgx.First

--- a/pkg/web/api/handle_corpus_import.go
+++ b/pkg/web/api/handle_corpus_import.go
@@ -1,0 +1,228 @@
+package api
+
+import (
+	"bytes"
+	"encoding/csv"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+	"unicode/utf8"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/liut/morign/pkg/models/corpus"
+	"github.com/liut/morign/pkg/services/stores"
+)
+
+const maxImportUploadSize = 10 << 20 // 10 MiB
+
+func init() {
+	regHI(true, "POST", "/corpus/imports", "corpus-imports-post", func(a *api) http.HandlerFunc {
+		return a.postCorpusImport
+	})
+	regHI(true, "GET", "/corpus/imports", "corpus-imports-get", func(a *api) http.HandlerFunc {
+		return a.getCorpusImports
+	})
+	regHI(true, "GET", "/corpus/imports/:id", "corpus-imports-id-get", func(a *api) http.HandlerFunc {
+		return a.getCorpusImport
+	})
+}
+
+// corpusImportTaskView 任务视图：剔除 CSV 原文；列表复用（Errors 置空即不输出）
+// @name corpusImportTaskView
+type corpusImportTaskView struct {
+	ID         string                  `json:"id"`
+	Filename   string                  `json:"filename"`
+	Status     corpus.ImportTaskStatus `json:"status"`
+	Total      int                     `json:"total"`
+	Success    int                     `json:"success"`
+	Failed     int                     `json:"failed"`
+	Skipped    int                     `json:"skipped"`
+	Errors     []corpus.ImportFailure  `json:"errors,omitempty"`
+	CreatedAt  time.Time               `json:"createdAt"`
+	UpdatedAt  *time.Time              `json:"updatedAt,omitempty"`
+	StartedAt  *time.Time              `json:"startedAt,omitempty"`
+	FinishedAt *time.Time              `json:"finishedAt,omitempty"`
+}
+
+func newImportTaskView(obj *corpus.ImportTask) *corpusImportTaskView {
+	return &corpusImportTaskView{
+		ID:         obj.StringID(),
+		Filename:   obj.Filename,
+		Status:     obj.Status,
+		Total:      obj.Total,
+		Success:    obj.Success,
+		Failed:     obj.Failed,
+		Skipped:    obj.Skipped,
+		Errors:     obj.Errors,
+		CreatedAt:  obj.CreatedAt,
+		UpdatedAt:  obj.UpdatedAt,
+		StartedAt:  obj.StartedAt,
+		FinishedAt: obj.FinishedAt,
+	}
+}
+
+// @Tags 语料 文档导入
+// @Summary 上传 CSV 创建导入任务 🔑
+// @Accept mpfd
+// @Produce json
+// @Param token header string true "登录票据凭证"
+// @Param file formData file true "CSV 文件（title,heading,content，UTF-8）"
+// @Success 200 {object} Done{result=corpusImportTaskView}
+// @Failure 400 {object} Failure "请求或参数错误"
+// @Failure 401 {object} Failure "未登录"
+// @Failure 403 {object} Failure "无权限"
+// @Failure 413 {object} Failure "文件过大"
+// @Failure 503 {object} Failure "服务端错误"
+// @Router /api/corpus/imports [post]
+func (a *api) postCorpusImport(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxImportUploadSize)
+	file, fh, err := r.FormFile("file")
+	if err != nil {
+		if isTooLarge(err) {
+			fail(w, r, 413, "file too large, max 10MiB")
+			return
+		}
+		fail(w, r, 400, "missing file field")
+		return
+	}
+	defer func() { _ = file.Close() }()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		if isTooLarge(err) {
+			fail(w, r, 413, "file too large, max 10MiB")
+			return
+		}
+		fail(w, r, 400, err)
+		return
+	}
+	if !utf8.Valid(data) {
+		fail(w, r, 400, "file must be UTF-8 encoded")
+		return
+	}
+	data = bytes.TrimPrefix(data, []byte("\xef\xbb\xbf"))
+	if !validImportCSVHead(data) {
+		fail(w, r, 400, "invalid csv header, expected: title,heading,content")
+		return
+	}
+
+	obj, err := a.sto.Corpus().CreateImportTask(r.Context(), corpus.ImportTaskBasic{
+		Filename: fh.Filename,
+		Status:   corpus.ImportTaskStatusPending,
+		Data:     string(data),
+	})
+	if err != nil {
+		fail(w, r, 503, err)
+		return
+	}
+	success(w, r, newImportTaskView(obj))
+}
+
+// @Tags 语料 文档导入
+// @Summary 查询导入任务列表 🔑
+// @Description <sortable>created,filename,status</sortable>
+// @Accept json
+// @Produce json
+// @Param token header string true "登录票据凭证"
+// @Param query query stores.CobImportTaskSpec true "Object"
+// @Success 200 {object} Done{result=ResultData{data=[]corpusImportTaskView}}
+// @Failure 400 {object} Failure "请求或参数错误"
+// @Failure 401 {object} Failure "未登录"
+// @Failure 403 {object} Failure "无权限"
+// @Failure 503 {object} Failure "服务端错误"
+// @Router /api/corpus/imports [get]
+func (a *api) getCorpusImports(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	var spec stores.CobImportTaskSpec
+	if s := q.Get("status"); s != "" {
+		if err := spec.Status.Decode(s); err != nil {
+			fail(w, r, 400, err)
+			return
+		}
+	}
+	spec.Filename = q.Get("filename")
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			fail(w, r, 400, "invalid limit")
+			return
+		}
+		spec.Limit = n
+	} else {
+		spec.Limit = 20
+	}
+	if v := q.Get("page"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			fail(w, r, 400, "invalid page")
+			return
+		}
+		spec.Page = n
+	}
+	spec.Sort = q.Get("sort")
+	if spec.Sort == "" {
+		spec.Sort = "-created"
+	}
+	spec.ExcludeColumn("data", "errors")
+
+	data, total, err := a.sto.Corpus().ListImportTask(r.Context(), &spec)
+	if err != nil {
+		fail(w, r, 503, err)
+		return
+	}
+
+	items := make([]*corpusImportTaskView, len(data))
+	for i := range data {
+		items[i] = newImportTaskView(&data[i])
+		items[i].Errors = nil
+	}
+	success(w, r, dtResult(items, total))
+}
+
+// @Tags 语料 文档导入
+// @Summary 获取导入任务详情 🔑
+// @Accept json
+// @Produce json
+// @Param token header string true "登录票据凭证"
+// @Param id path string true "任务ID"
+// @Success 200 {object} Done{result=corpusImportTaskView}
+// @Failure 400 {object} Failure "请求或参数错误"
+// @Failure 401 {object} Failure "未登录"
+// @Failure 403 {object} Failure "无权限"
+// @Failure 404 {object} Failure "目标未找到"
+// @Failure 503 {object} Failure "服务端错误"
+// @Router /api/corpus/imports/{id} [get]
+func (a *api) getCorpusImport(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	obj, err := a.sto.Corpus().GetImportTask(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, stores.ErrNotFound) {
+			fail(w, r, 404, err)
+			return
+		}
+		if errors.Is(err, stores.ErrInvalidID) {
+			fail(w, r, 400, err)
+			return
+		}
+		fail(w, r, 503, err)
+		return
+	}
+	success(w, r, newImportTaskView(obj))
+}
+
+func isTooLarge(err error) bool {
+	var maxErr *http.MaxBytesError
+	return errors.As(err, &maxErr)
+}
+
+func validImportCSVHead(data []byte) bool {
+	rd := csv.NewReader(bytes.NewReader(data))
+	rec, err := rd.Read()
+	if err != nil {
+		return false
+	}
+	return stores.ValidHead(rec)
+}

--- a/pkg/web/api/handle_corpus_import_test.go
+++ b/pkg/web/api/handle_corpus_import_test.go
@@ -1,0 +1,344 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cupogo/andvari/models/oid"
+	"github.com/go-chi/chi/v5"
+	auth "github.com/liut/simpauth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/liut/morign/pkg/models/aigc"
+	"github.com/liut/morign/pkg/models/corpus"
+	"github.com/liut/morign/pkg/services/stores"
+	"github.com/liut/morign/pkg/settings"
+)
+
+type fakeCorpuStore struct {
+	stores.CorpuStore
+	seq     int
+	created []corpus.ImportTaskBasic
+	tasks   []corpus.ImportTask
+}
+
+func (f *fakeCorpuStore) CreateImportTask(ctx context.Context, in corpus.ImportTaskBasic) (*corpus.ImportTask, error) {
+	f.created = append(f.created, in)
+	f.seq++
+	obj := corpus.NewImportTaskWithBasic(in)
+	obj.SetID(oid.NewID(oid.OtTask))
+	f.tasks = append(f.tasks, *obj)
+	return obj, nil
+}
+
+func (f *fakeCorpuStore) ListImportTask(ctx context.Context, spec *stores.CobImportTaskSpec) (corpus.ImportTasks, int, error) {
+	var data corpus.ImportTasks
+	for i := range f.tasks {
+		t := f.tasks[i]
+		if spec.Status != 0 && t.Status != spec.Status {
+			continue
+		}
+		data = append(data, t)
+	}
+	return data, len(data), nil
+}
+
+func (f *fakeCorpuStore) GetImportTask(ctx context.Context, id string) (*corpus.ImportTask, error) {
+	for i := range f.tasks {
+		if f.tasks[i].StringID() == id {
+			return &f.tasks[i], nil
+		}
+	}
+	if !oid.Cast(id).Valid() {
+		return nil, stores.ErrInvalidID
+	}
+	return nil, stores.ErrNotFound
+}
+
+type importFakeStorage struct {
+	corpu *fakeCorpuStore
+}
+
+func (f *importFakeStorage) Preset() aigc.Preset                { return aigc.Preset{} }
+func (f *importFakeStorage) Corpus() stores.CorpuStore          { return f.corpu }
+func (f *importFakeStorage) KB() stores.CorpuStore              { return f.corpu }
+func (f *importFakeStorage) MCP() stores.MCPStore               { return nil }
+func (f *importFakeStorage) Convo() stores.ConvoStore           { return nil }
+func (f *importFakeStorage) State() stores.StateStore           { return nil }
+func (f *importFakeStorage) Capability() stores.CapabilityStore { return nil }
+func (f *importFakeStorage) Skill() stores.SkillStore           { return nil }
+
+func importAPI() (*api, *fakeCorpuStore) {
+	fc := &fakeCorpuStore{}
+	return &api{sto: &importFakeStorage{corpu: fc}}, fc
+}
+
+func importRouter(a *api) *chi.Mux {
+	r := chi.NewRouter()
+	r.Use(a.authPerm("corpus-imports"))
+	r.Post("/api/corpus/imports", a.postCorpusImport)
+	r.Get("/api/corpus/imports", a.getCorpusImports)
+	r.Get("/api/corpus/imports/{id}", a.getCorpusImport)
+	return r
+}
+
+func withKeeper(req *http.Request) *http.Request {
+	ctx := auth.ContextWithUser(req.Context(), &auth.User{
+		OID:   "o1",
+		UID:   "keeper",
+		Name:  "keeper",
+		Roles: []string{settings.Current.KeeperRole},
+	})
+	return req.WithContext(ctx)
+}
+
+func withNonKeeper(req *http.Request) *http.Request {
+	ctx := auth.ContextWithUser(req.Context(), &auth.User{
+		OID:   "o2",
+		UID:   "user",
+		Name:  "user",
+		Roles: []string{"user"},
+	})
+	return req.WithContext(ctx)
+}
+
+func multipartCSVRequest(t *testing.T, filename, content string) *http.Request {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile("file", filename)
+	require.NoError(t, err)
+	_, err = fw.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, mw.Close())
+	req := httptest.NewRequest(http.MethodPost, "/api/corpus/imports", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	return req
+}
+
+func decodeResult(t *testing.T, rr *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &m))
+	return m
+}
+
+func TestImportUploadAPI(t *testing.T) {
+	a, fc := importAPI()
+	r := importRouter(a)
+
+	csv := "\xef\xbb\xbftitle,heading,content\nhello,a,world\n"
+	req := multipartCSVRequest(t, "docs.csv", csv)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, withKeeper(req))
+
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	result := decodeResult(t, rr)["result"].(map[string]any)
+	assert.Equal(t, "docs.csv", result["filename"])
+	assert.Equal(t, "pending", result["status"])
+	assert.NotContains(t, result, "data")
+	assert.NotContains(t, result, "errors")
+
+	require.Len(t, fc.created, 1)
+	assert.Equal(t, "title,heading,content\nhello,a,world\n", fc.created[0].Data, "BOM must be stripped")
+	assert.Equal(t, corpus.ImportTaskStatusPending, fc.created[0].Status)
+}
+
+func TestImportUploadAPIAuth(t *testing.T) {
+	a, fc := importAPI()
+	r := importRouter(a)
+
+	req := multipartCSVRequest(t, "docs.csv", "title,heading,content\nhello,a,world\n")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+
+	req = multipartCSVRequest(t, "docs.csv", "title,heading,content\nhello,a,world\n")
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, withNonKeeper(req))
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+
+	req = multipartCSVRequest(t, "docs.csv", "title,heading,content\nhello,a,world\n")
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, withKeeper(req))
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Len(t, fc.created, 1)
+}
+
+func TestImportUploadAPIValidation(t *testing.T) {
+	a, fc := importAPI()
+	r := importRouter(a)
+
+	cases := []struct {
+		name    string
+		content string
+		want    int
+	}{
+		{"bad header", "a,b,c\nx,y,z\n", http.StatusBadRequest},
+		{"non utf8", "title,heading,content\n\xff\xfe\x00\n", http.StatusBadRequest},
+		{"too large", strings.Repeat("a", maxImportUploadSize+1), http.StatusRequestEntityTooLarge},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := multipartCSVRequest(t, "docs.csv", c.content)
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, withKeeper(req))
+			assert.Equal(t, c.want, respCode(t, rr), rr.Body.String())
+		})
+	}
+	assert.Empty(t, fc.created)
+}
+
+func TestImportUploadAPIMissingFile(t *testing.T) {
+	a, fc := importAPI()
+	r := importRouter(a)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/corpus/imports", strings.NewReader("title,heading,content\n"))
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, withKeeper(req))
+
+	assert.Equal(t, http.StatusBadRequest, respCode(t, rr))
+	assert.Empty(t, fc.created)
+}
+
+func TestImportListAPI(t *testing.T) {
+	a, fc := importAPI()
+	r := importRouter(a)
+
+	for i, status := range []corpus.ImportTaskStatus{
+		corpus.ImportTaskStatusPending,
+		corpus.ImportTaskStatusSucceeded,
+		corpus.ImportTaskStatusFailed,
+	} {
+		obj := corpus.NewImportTaskWithBasic(corpus.ImportTaskBasic{
+			Filename: "docs.csv",
+			Status:   status,
+			Data:     "secret-csv",
+			Total:    i + 1,
+		})
+		obj.SetID(oid.NewID(oid.OtTask))
+		fc.tasks = append(fc.tasks, *obj)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/corpus/imports", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, withKeeper(req))
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	result := decodeResult(t, rr)["result"].(map[string]any)
+	assert.Equal(t, float64(3), result["total"])
+	items := result["data"].([]any)
+	require.Len(t, items, 3)
+	for _, item := range items {
+		m := item.(map[string]any)
+		assert.NotContains(t, m, "data")
+		assert.NotContains(t, m, "errors")
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/corpus/imports?status=pending", nil)
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, withKeeper(req))
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	result = decodeResult(t, rr)["result"].(map[string]any)
+	assert.Equal(t, float64(1), result["total"])
+
+	req = httptest.NewRequest(http.MethodGet, "/api/corpus/imports?status=1", nil)
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, withKeeper(req))
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	result = decodeResult(t, rr)["result"].(map[string]any)
+	assert.Equal(t, float64(1), result["total"])
+
+	req = httptest.NewRequest(http.MethodGet, "/api/corpus/imports?status=bogus", nil)
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, withKeeper(req))
+	assert.Equal(t, http.StatusBadRequest, respCode(t, rr))
+}
+
+func TestImportListAPIAuth(t *testing.T) {
+	a, _ := importAPI()
+	r := importRouter(a)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/corpus/imports", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, withNonKeeper(req))
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestImportDetailAPI(t *testing.T) {
+	a, fc := importAPI()
+	r := importRouter(a)
+
+	obj := corpus.NewImportTaskWithBasic(corpus.ImportTaskBasic{
+		Filename: "docs.csv",
+		Status:   corpus.ImportTaskStatusSucceeded,
+		Data:     "secret-csv",
+		Total:    2,
+		Success:  1,
+		Failed:   1,
+		Errors: []corpus.ImportFailure{{
+			Line:   3,
+			Title:  "hello",
+			Reason: "数据无效",
+		}},
+	})
+	obj.SetID(oid.NewID(oid.OtTask))
+	fc.tasks = append(fc.tasks, *obj)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/corpus/imports/"+obj.StringID(), nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, withKeeper(req))
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	result := decodeResult(t, rr)["result"].(map[string]any)
+	assert.NotContains(t, result, "data")
+	assert.Equal(t, "succeeded", result["status"])
+	assert.Equal(t, float64(2), result["total"])
+	errs := result["errors"].([]any)
+	require.Len(t, errs, 1)
+	assert.Equal(t, float64(3), errs[0].(map[string]any)["line"])
+}
+
+func TestImportDetailAPINotFound(t *testing.T) {
+	a, _ := importAPI()
+	r := importRouter(a)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/corpus/imports/"+oid.NewObjID(oid.OtTask), nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, withKeeper(req))
+	assert.Equal(t, http.StatusNotFound, respCode(t, rr))
+}
+
+func TestImportDetailAPIInvalidID(t *testing.T) {
+	a, _ := importAPI()
+	r := importRouter(a)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/corpus/imports/not-an-oid", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, withKeeper(req))
+	assert.Equal(t, http.StatusBadRequest, respCode(t, rr))
+}
+
+func TestImportListAPIInvalidPaging(t *testing.T) {
+	a, _ := importAPI()
+	r := importRouter(a)
+
+	for _, q := range []string{"limit=abc", "limit=-1", "limit=0", "page=abc", "page=-1", "page=0"} {
+		req := httptest.NewRequest(http.MethodGet, "/api/corpus/imports?"+q, nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, withKeeper(req))
+		assert.Equal(t, http.StatusBadRequest, respCode(t, rr), "query %s", q)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/corpus/imports?limit=1&page=1", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, withKeeper(req))
+	assert.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+}


### PR DESCRIPTION
Add the ImportTask model and status enum plus LGCUD store scaffolding generated from docs/corpus.yaml, and the claim/process/recover logic: atomic pending-to-processing claim, row-by-row CSV import with duplicate skip and capped failure details, and processing-to-pending recovery for tasks interrupted by a crash.

Run a serial worker from webRun that recovers stuck tasks on startup, then processes one task at a time with a short idle poll, exiting on context cancel.

Expose keeper-only endpoints: POST /api/corpus/imports uploads a UTF-8 CSV (10MiB cap, BOM stripped, header validated), GET /api/corpus/imports lists tasks newest-first with status/filename filters and pagination, and GET /api/corpus/imports/{id} returns counts and failure details. Invalid ids and paging params return 400. Regenerate swagger docs.